### PR TITLE
Assorted fixes for Git for windows

### DIFF
--- a/newlib/libc/stdlib/mbtowc_r.c
+++ b/newlib/libc/stdlib/mbtowc_r.c
@@ -48,7 +48,7 @@ _DEFUN (__ascii_mbtowc, (r, pwc, s, n, charset, state),
   if (n == 0)
     return -2;
 
-#ifdef __CYGWIN__
+#ifdef STRICTLY_7BIT_ASCII
   if ((wchar_t)*t >= 0x80)
     {
       r->_errno = EILSEQ;

--- a/newlib/libc/stdlib/wctomb_r.c
+++ b/newlib/libc/stdlib/wctomb_r.c
@@ -41,7 +41,7 @@ _DEFUN (__ascii_wctomb, (r, s, wchar, charset, state),
   if (s == NULL)
     return 0;
  
-#ifdef __CYGWIN__
+#ifdef STRICTLY_7BIT_ASCII
   if ((size_t)wchar >= 0x80)
 #else
   if ((size_t)wchar >= 0x100)

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -1244,7 +1244,7 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
 	     Note that this doesn't stop invalid strings without '=' in it
 	     etc., but we're opting for speed here for now.  Adding complete
 	     checking would be pretty expensive. */
-	  if (len == 1 || !*rest)
+	  if (len == 1)
 	    continue;
 
 	  /* See if this entry requires posix->win32 conversion. */

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -1135,7 +1135,12 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
       bool calc_tl = !no_envblock;
       /* Don't pass timezone environment to non-msys applications */
       if (!keep_posix && ascii_strncasematch(*srcp, "TZ=", 3))
-        goto next1;
+        {
+          *dstp = (char *) cmalloc (HEAP_1_STR, strlen (*srcp) + 7);
+          strcpy (*dstp, "MSYS2_");
+          strcpy (*dstp + 6, *srcp);
+          goto next0;
+        }
       /* Look for entries that require special attention */
       for (unsigned i = 0; i < SPENVS_SIZE; i++)
 	if (!saw_spenv[i] && (*dstp = spenvs[i].retrieve (no_envblock, *srcp)))

--- a/winsup/cygwin/how-to-debug-cygwin.txt
+++ b/winsup/cygwin/how-to-debug-cygwin.txt
@@ -126,3 +126,9 @@ set CYGWIN_DEBUG=cat.exe:gdb.exe
    program will crash, probably in small_printf.  At that point, a 'bt'
    command should show you the offending call to strace_printf with the
    improper format string.
+
+9. Debug output without strace
+
+   If you cannot use gdb, or if the program behaves differently using strace
+   for whatever reason, you can still use the small_printf() function to
+   output debugging messages directly to stderr.

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -449,6 +449,8 @@ skip_p2w:
 
     int starts_with_minus = 0;
     int starts_with_minus_alpha = 0;
+    int only_dots = *it == '.';
+    int has_slashes = 0;
     if (*it == '-') {
       starts_with_minus = 1;
       it += 1;
@@ -489,11 +491,17 @@ skip_p2w:
                 if (ch == '/' && *(it2 + 1) == '/') {
                     return URL;
                 } else {
+                    if (!only_dots && !has_slashes)
+                        goto skip_p2w;
                     return POSIX_PATH_LIST;
                 }
             } else if (memchr(it2, '=', end - it) == NULL) {
                 return SIMPLE_WINDOWS_PATH;
             }
+        } else if (ch != '.') {
+            only_dots = 0;
+            if (ch == '/' || ch == '\\')
+                has_slashes = 1;
         }
     }
 

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -358,6 +358,10 @@ skip_p2w:
         case '[':
         case ']':
             goto skip_p2w;
+        case '/':
+            if (it + 1 < end && it[1] == '~')
+                goto skip_p2w;
+            break;
         ++it;
     }
     it = *src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -375,6 +375,11 @@ skip_p2w:
                     goto skip_p2w;
             }
             break;
+        case '@':
+            // Paths do not contain '@@'
+            if (it + 1 < end && it[1] == '@')
+                goto skip_p2w;
+        }
         ++it;
     }
     it = *src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -366,6 +366,14 @@ skip_p2w:
             // Avoid mangling IPv6 addresses
             if (it + 1 < end && it[1] == ':')
                 goto skip_p2w;
+
+            // Leave Git's <rev>:./name syntax alone
+            if (it + 1 < end && it[1] == '.') {
+                if (it + 2 < end && it[2] == '/')
+                    goto skip_p2w;
+                if (it + 3 < end && it[2] == '.' && it[3] == '/')
+                    goto skip_p2w;
+            }
             break;
         ++it;
     }

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -335,8 +335,10 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
 
     if (*it == '\0' || it == end) return NONE;
 
-    if (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
-        return find_path_start_and_type(move(src, 1), true, end);
+    while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
+        recurse = true;
+        it = ++*src;
+        if (it == end || *it == '\0') return NONE;
     }
 
     path_type result = NONE;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -342,6 +342,12 @@ skip_p2w:
         return NONE;
     }
 
+    /*
+     * Prevent Git's :file.txt and :/message syntax from beeing modified.
+     */
+    if (*it == ':')
+        goto skip_p2w;
+
     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -237,6 +237,7 @@ void find_end_of_rooted_path(const char** from, const char** to, int* in_string)
 void sub_convert(const char** from, const char** to, char** dst, const char* dstend, int* in_string) {
     const char* copy_from = *from;
     path_type type = find_path_start_and_type(from, false, *to);
+    debug_printf("found type %d for path %s", type, copy_from);
 
     if (type == POSIX_PATH_LIST) {
         find_end_of_posix_list(to, in_string);

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -200,7 +200,7 @@ void ppl_convert(const char** from, const char* to, char** dst, const char* dste
 
 
 void find_end_of_posix_list(const char** to, int* in_string) {
-    for (; **to != '\0' && (in_string ? (**to != *in_string) : **to != ' '); ++*to) {
+    for (; **to != '\0' && (!in_string || **to != *in_string); ++*to) {
     }
 
     if (**to == *in_string) {
@@ -298,12 +298,6 @@ const char* convert(char *dst, size_t dstlen, const char *src) {
                 in_string = *srcit;
             }
             continue;
-        }
-
-        if (isspace(*srcit)) {
-            //sub_convert(&srcbeg, &srcit, &dstit, dstend, &in_string);
-            //srcbeg = srcit + 1;
-            break;
         }
     }
 

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -348,6 +348,20 @@ skip_p2w:
     if (*it == ':')
         goto skip_p2w;
 
+    while (it != end && *it) {
+        switch (*it) {
+        case '`':
+        case '\'':
+        case '"':
+        case '*':
+        case '?':
+        case '[':
+        case ']':
+            goto skip_p2w;
+        ++it;
+    }
+    it = *src;
+
     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -362,6 +362,11 @@ skip_p2w:
             if (it + 1 < end && it[1] == '~')
                 goto skip_p2w;
             break;
+        case ':':
+            // Avoid mangling IPv6 addresses
+            if (it + 1 < end && it[1] == ':')
+                goto skip_p2w;
+            break;
         ++it;
     }
     it = *src;

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -335,6 +335,13 @@ path_type find_path_start_and_type(const char** src, int recurse, const char* en
 
     if (*it == '\0' || it == end) return NONE;
 
+    /* Let's not convert ~/.file to ~C:\msys64\.file */
+    if (*it == '~') {
+skip_p2w:
+        *src = end;
+        return NONE;
+    }
+
     while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -715,11 +715,11 @@ path_conv::check (const char *src, unsigned opt,
 	      need_directory = 1;
 	      *--tail = '\0';
 	    }
-	  /* Special case for "/" must set need_directory, without removing
+	  /* Special case for "/" must not set need_directory, neither remove
 	     trailing slash */
 	  else if (tail == path_copy + 1 && isslash (tail[-1]))
 	    {
-	      need_directory = 1;
+	      need_directory = 0;
 	    }
 	  path_end = tail;
 

--- a/winsup/cygwin/strfuncs.cc
+++ b/winsup/cygwin/strfuncs.cc
@@ -618,7 +618,11 @@ sys_cp_mbstowcs (mbtowc_p f_mbtowc, const char *charset, wchar_t *dst,
 	     to store them in a symmetric way. */
 	  bytes = 1;
 	  if (dst)
+#ifdef STRICTLY_7BIT_ASCII
 	    *ptr = L'\xf000' | *pmbs;
+#else
+	    *ptr = *pmbs;
+#endif
 	  memset (&ps, 0, sizeof ps);
 	}
 


### PR DESCRIPTION
Git for Windows is about to switch to an MSys2-based development environment. The major road block was that the test suite did not pass when building Git in such an environment.

These changes are required to support Git for Windows, and together with a couple more commits to Git for Windows' own source code, makes the test suite pass.