### PR TITLE
path-converting-fix

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -384,7 +384,7 @@ skip_p2w:
     }
     it = *src;
 
-    while (!isalnum(*it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
+    while (!isalnum(*it) && !(0x80 & *it) && *it != '/' && *it != '\\' && *it != ':' && *it != '-' && *it != '.') {
         recurse = true;
         it = ++*src;
         if (it == end || *it == '\0') return NONE;


### PR DESCRIPTION
When a non ascii char is at the beginning of a path the current conversion
destroys the path. This fix will prevent this with an extra check for
non-ascii UTF-8 characters.