### PR TITLE
Tell non-MSys2 executables whether they are connected to a terminal

### DIFF
--- a/winsup/cygwin/cygheap.h
+++ b/winsup/cygwin/cygheap.h
@@ -138,6 +138,7 @@ public:
   const char *env_domain (const char *, size_t);
   const char *env_name (const char *, size_t);
   const char *env_systemroot (const char *, size_t);
+  const char *env_tty_handles (const char *, size_t);
 
   const char *logsrv ()
   {

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -963,7 +963,8 @@ static NO_COPY spenv spenvs[] =
   {NL ("USERDOMAIN="), false, false, &cygheap_user::env_domain},
   {NL ("USERNAME="), false, false, &cygheap_user::env_name},
   {NL ("USERPROFILE="), false, false, &cygheap_user::env_userprofile},
-  {NL ("WINDIR="), true, true, &cygheap_user::env_systemroot}
+  {NL ("WINDIR="), true, true, &cygheap_user::env_systemroot},
+  {NL ("MSYS_TTY_HANDLES="), true, true, &cygheap_user::env_tty_handles}
 };
 
 char *

--- a/winsup/cygwin/uinfo.cc
+++ b/winsup/cygwin/uinfo.cc
@@ -543,6 +543,33 @@ cygheap_user::env_systemroot (const char *name, size_t namelen)
   return psystemroot;
 }
 
+const char *
+cygheap_user::env_tty_handles(const char *name, size_t namelen)
+{
+  static unsigned initialized;
+  static char buffer[128];
+
+  if (!initialized)
+    {
+      int fd;
+      char *p = buffer + sprintf(buffer, " ");
+      for (fd = 0; fd < 3; fd++)
+        if (isatty(fd))
+          {
+            cygheap_fdget cfd (fd);
+
+            if (cfd < 0 || cfd->close_on_exec ())
+              continue;
+
+            p += sprintf(p, "%ld ", (unsigned long)
+              (fd ?  cfd->get_output_handle() : cfd->get_handle()));
+          }
+      initialized = 1;
+    }
+
+  return buffer;
+}
+
 char *
 pwdgrp::next_str (char c)
 {


### PR DESCRIPTION
By setting the MSYS_TTY_HANDLES environment variable to a list of
Win32 handles corresponding to terminals connected to
stdin/stdout/stderr, we help non-MSys2 executables (which cannot simply
use MSys2's isatty()) to tell whether their standard file descriptors
are redirected or not.

To make things as convenient as possible, the list is delimited by
spaces on both sides of the elements so that to find out whether stdin
is actually a terminal, one just needs to look for the needle
" <handle> " in $MSYS_TTY_HANDLES (where <handle> is the decimal
representation of GetStdHandle(STD_INPUT_HANDLE)).

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>