### PR TITLE
Revert "Fall back to HOME environment variable"

### DIFF
--- a/winsup/cygwin/uinfo.cc
+++ b/winsup/cygwin/uinfo.cc
@@ -2494,43 +2494,6 @@ pwdgrp::fetch_account_from_windows (fetch_user_arg_t &arg, cyg_ldap *pldap)
     p = wcpcpy (wcpcpy (p, dom), cygheap->pg.nss_separator ());
   wcpcpy (p, name);
 
-  if (!home)
-    {
-      char *env = getenv("HOME");
-      if (!env)
-        {
-          char *drive = getenv("HOMEDRIVE"), *path = getenv("HOMEPATH");
-          if (drive && path)
-            {
-              int drive_len = strlen(drive), path_len = strlen(path);
-              home = (char *)malloc(drive_len + path_len + 1);
-              strcpy(home, drive);
-              strcpy(home + drive_len, path);
-            }
-        }
-      if (!home && !env)
-        env = getenv("USERPROFILE");
-
-      if (env)
-        home = strdup(env);
-
-      /* Poor man's win32 -> POSIX conversion */
-      // is not available on 64-bit: cygwin_conv_to_posix_path(env, home);
-      if (home)
-        {
-          int i;
-
-          if (isalpha(home[0]) && home[1] == ':')
-            {
-              home[1] = home[0];
-              home[0] = '/';
-            }
-          for (i = 0; home[i]; i++)
-            if (home[i] == '\\')
-              home[i] = '/';
-        }
-    }
-
   if (is_group ())
     __small_sprintf (linebuf, "%W:%s:%u:",
 		     posix_name, sid.string ((char *) sidstr), uid);


### PR DESCRIPTION
This reverts commit 8f13f65bfeec5b561261110814b5c5f75acd569e.

@Alexpux [says](https://github.com/git-for-windows/msys2-runtime/commit/8f13f65bfeec5b561261110814b5c5f75acd569e#commitcomment-10168946): "This is bad. If you want to use Windows home directory
for users you need just provide proper /etc/nsswitch.conf file."

So we use this /etc/nsswitch.conf now, as per the description in
https://cyginw.com/cygwin-ug-net/ntsec.html#ntesec-mapping-nsswitch:

	passwd: files db
	group: files db

	db_enum: cache builtin

	db_home: windows cygwin desc
	db_shell: windows cygwin desc
	db_gecos: windows cygwin desc

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>