### PR TITLE
When interrupting Win32 processes, kill their child processes, too

### DIFF
--- a/winsup/cygwin/common.din
+++ b/winsup/cygwin/common.din
@@ -33,6 +33,7 @@ sys_errlist = _sys_errlist DATA
 sys_nerr = _sys_nerr DATA
 sys_sigabbrev DATA
 sys_siglist DATA
+kill_process_tree DATA
 
 # Exported functions
 _Exit SIGFE

--- a/winsup/cygwin/exceptions.cc
+++ b/winsup/cygwin/exceptions.cc
@@ -1479,7 +1479,10 @@ dosig:
   if (have_execed)
     {
       sigproc_printf ("terminating captive process");
-      TerminateProcess (ch_spawn, sigExeced = si.si_signo);
+      if ((sigExeced = si.si_signo) == SIGINT)
+        kill_process_tree (GetProcessId (ch_spawn), sigExeced = si.si_signo);
+      else
+        TerminateProcess (ch_spawn, sigExeced = si.si_signo);
     }
   /* Dispatch to the appropriate function. */
   sigproc_printf ("signal %d, signal handler %p", si.si_signo, handler);

--- a/winsup/cygwin/include/cygwin/signal.h
+++ b/winsup/cygwin/include/cygwin/signal.h
@@ -400,6 +400,7 @@ extern const char *sys_siglist[];
 extern const char __declspec(dllimport) *sys_sigabbrev[];
 extern const char __declspec(dllimport) *sys_siglist[];
 #endif
+void kill_process_tree(pid_t pid, int sig);
 
 #ifdef __cplusplus
 }

--- a/winsup/cygwin/include/cygwin/signal.h
+++ b/winsup/cygwin/include/cygwin/signal.h
@@ -396,11 +396,12 @@ int siginterrupt (int, int);
 #ifdef __INSIDE_CYGWIN__
 extern const char *sys_sigabbrev[];
 extern const char *sys_siglist[];
+extern void kill_process_tree(pid_t pid, int sig);
 #else
 extern const char __declspec(dllimport) *sys_sigabbrev[];
 extern const char __declspec(dllimport) *sys_siglist[];
+extern void __declspec(dllimport) kill_process_tree(pid_t pid, int sig);
 #endif
-void kill_process_tree(pid_t pid, int sig);
 
 #ifdef __cplusplus
 }

--- a/winsup/cygwin/include/cygwin/version.h
+++ b/winsup/cygwin/include/cygwin/version.h
@@ -469,12 +469,13 @@ details. */
       285: Export wcstold.
       286: Export cabsl, cimagl, creall, finitel, hypotl, sqrtl.
       287: Export issetugid.
+      288: Export kill_process_tree.
      */
 
      /* Note that we forgot to bump the api for ualarm, strtoll, strtoull */
 
 #define CYGWIN_VERSION_API_MAJOR 0
-#define CYGWIN_VERSION_API_MINOR 287
+#define CYGWIN_VERSION_API_MINOR 288
 
      /* There is also a compatibity version number associated with the
 	shared memory regions.  It is incremented when incompatible

--- a/winsup/utils/kill.cc
+++ b/winsup/utils/kill.cc
@@ -174,10 +174,14 @@ forcekill (int pid, int sig, int wait)
       return;
     }
   if (!wait || WaitForSingleObject (h, 200) != WAIT_OBJECT_0)
-    if (sig && !TerminateProcess (h, sig << 8)
-	&& WaitForSingleObject (h, 200) != WAIT_OBJECT_0)
-      fprintf (stderr, "%s: couldn't kill pid %u, %u\n",
+    {
+      if (sig == SIGINT || sig == SIGTERM)
+        kill_process_tree (dwpid, sig);
+      else if (sig && !TerminateProcess (h, sig << 8)
+          && WaitForSingleObject (h, 200) != WAIT_OBJECT_0)
+        fprintf (stderr, "%s: couldn't kill pid %u, %u\n",
 	       prog_name, (unsigned) dwpid, (unsigned int) GetLastError ());
+    }
   CloseHandle (h);
 }
 


### PR DESCRIPTION
The symptom fixed by this PR is that interrupting a `git clone https://...` with Ctrl+C in mintty does not terminate the clone, but sends the process into the background, with an unnerving unstoppable progress output to the terminal.

The reason is that calling `TerminateProcess()` does not affect the processes spawned off of the terminated process.

Note: this only affects processes interrupted in `mintty` via Ctrl+C; If the Ctrl+C is handled in a `cmd.exe`-backed terminal window, it is already handled correctly.