### PR TITLE
Pass the TZ variable to non-msys programs if it is standard-compliant

### DIFF
--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -1139,13 +1139,16 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
     {
       bool calc_tl = !no_envblock;
 #ifdef __MSYS__
-      /* Don't pass timezone environment to non-msys applications */
+      /* Don't pass non-standard timezone to non-msys applications */
       if (!keep_posix && ascii_strncasematch(*srcp, "TZ=", 3))
         {
-          *dstp = (char *) cmalloc (HEAP_1_STR, strlen (*srcp) + 7);
-          strcpy (*dstp, "MSYS2_");
-          strcpy (*dstp + 6, *srcp);
-          goto next0;
+	  const char *v = *srcp + 3;
+	  if (*v == ':')
+	    goto next1;
+	  for (; *v; v++)
+	    if (!isalpha(*v) && !isdigit(*v) &&
+	        *v != '-' && *v != '+' && *v != ':')
+	      goto next1;
         }
 #endif
       /* Look for entries that require special attention */


### PR DESCRIPTION
With this patch, we could get rid of the special MSYS_TZ handling in git, and TZ would also work for other native / mingw programs.