### PR TITLE
Allow overriding the home directory via the HOME variable

### DIFF
--- a/winsup/cygwin/cygheap.h
+++ b/winsup/cygwin/cygheap.h
@@ -415,7 +415,8 @@ public:
     NSS_SCHEME_UNIX,
     NSS_SCHEME_DESC,
     NSS_SCHEME_PATH,
-    NSS_SCHEME_FREEATTR
+    NSS_SCHEME_FREEATTR,
+    NSS_SCHEME_ENV
   };
   struct nss_scheme_t {
     nss_scheme_method	method;


### PR DESCRIPTION
In Git for Windows, it is a well-established technique to use the
`$HOME` variable to define where the current user's home directory is,
falling back to `$HOMEDRIVE$HOMEPATH` and `$USERPROFILE`.

This strategy is particular important when Cygwin, or command-line
programs depending on the HOME variable, cannot cope with the Windows'
idea of the user's home directory e.g. when it is set to a hidden
directory via an UNC path (\\share\some\hidden\folder$).

Of course this strategy needs to be opt-in. For that reason, this
strategy is activated via the `env` keyword in the `db_home` line in
`/etc/nsswitch.conf`.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>