### PR TITLE
Allow native symlinks to non-existing targets in 'nativestrict' mode

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1713,6 +1713,7 @@ symlink_native (const char *oldpath, path_conv &win32_newpath)
   path_conv win32_oldpath;
   PUNICODE_STRING final_oldpath, final_newpath;
   UNICODE_STRING final_oldpath_buf;
+  bool isdir;
 
   if (isabspath (oldpath))
     {
@@ -1773,15 +1774,39 @@ symlink_native (const char *oldpath, path_conv &win32_newpath)
 	  wcpcpy (e_old, c_old);
 	}
     }
-  /* If the symlink target doesn't exist, don't create native symlink.
-     Otherwise the directory flag in the symlink is potentially wrong
-     when the target comes into existence, and native tools will fail.
-     This is so screwball. This is no problem on AFS, fortunately. */
-  if (!win32_oldpath.exists () && !win32_oldpath.fs_is_afs ())
+
+  /* The directory flag in the symlink must match the target type,
+     otherwise native tools will fail (fortunately this is no problem
+     on AFS). Do our best to guess the symlink type correctly. */
+  if (win32_oldpath.exists () || win32_oldpath.fs_is_afs ())
     {
-      SetLastError (ERROR_FILE_NOT_FOUND);
-      return -1;
+      /* If the target exists (or on AFS), check the target type. Note
+	 that this may still be wrong if the target is changed after
+	 creating the symlink (e.g. in bulk operations such as rsync,
+	 unpacking archives or VCS checkouts). */
+      isdir = win32_oldpath.isdir ();
     }
+  else
+    {
+      if (allow_winsymlinks == WSYM_nativestrict)
+	{
+	  /* In nativestrict mode, if the target does not exist, use
+	     trailing '/' in the target path as hint to create a
+	     directory symlink. */
+	  ssize_t len = strlen(oldpath);
+	  isdir = len && isdirsep(oldpath[len - 1]);
+	}
+      else
+	{
+	 /* In native mode, if the target does not exist, fall back
+	    to creating a Cygwin symlink file (or in case of MSys:
+	    try to copy the (non-existing) target, which will of
+	    course fail). */
+	  SetLastError (ERROR_FILE_NOT_FOUND);
+	  return -1;
+	}
+    }
+
   /* Convert native paths to Win32 UNC paths. */
   final_newpath = win32_newpath.get_nt_native_path ();
   final_newpath->Buffer[1] = L'\\';
@@ -1806,8 +1831,7 @@ symlink_native (const char *oldpath, path_conv &win32_newpath)
     }
   /* Try to create native symlink. */
   if (!CreateSymbolicLinkW (final_newpath->Buffer, final_oldpath->Buffer,
-			    win32_oldpath.isdir ()
-			    ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0))
+			    isdir ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0))
     {
       /* Repair native newpath, we still need it. */
       final_newpath->Buffer[1] = L'?';


### PR DESCRIPTION
Prerequisite for issue https://github.com/git-for-windows/git/issues/117

Required to run the test suite with prereq SYMLINKS (with `export MSYS=winsymlinks:nativestrict`).
