### PR TITLE
path-conversion: Prevent conversion of commandline flags.

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -343,6 +343,14 @@ skip_p2w:
     }
 
     /*
+     * Skip path mangling when environment indicates it.
+     */
+    const char *no_pathconv = getenv ("MSYS_NO_PATHCONV");
+
+    if (no_pathconv)
+      goto skip_p2w;
+
+    /*
      * Prevent Git's :file.txt and :/message syntax from beeing modified.
      */
     if (*it == ':')


### PR DESCRIPTION
When calling windows apps from MSYS2, the runtime tries to convert
windows style commandline flags like ´/h´ into `C:/path/to/msys2/h`.

If the user does not want that behavior the user can now set the the
environment variable WINSTYLE_FLAGS_ONLY when calling that command.