### PR TITLE
sec_helper: Do not set Restore/Backup privileges

### DIFF
--- a/winsup/cygwin/sec_helper.cc
+++ b/winsup/cygwin/sec_helper.cc
@@ -480,9 +480,11 @@ set_cygwin_privileges (HANDLE token)
   /* Setting these rights at process startup allows processes running under
      user tokens which are in the administrstors group to have root-like
      permissions. */
+#if 0 /* Breaks access to some SMBv1 servers */
   /* Allow to access all files, independent of their ACL settings. */
   set_privilege (token, SE_RESTORE_PRIVILEGE, true);
   set_privilege (token, SE_BACKUP_PRIVILEGE, true);
+#endif
   /* Allow full access to other user's processes. */
   set_privilege (token, SE_DEBUG_PRIVILEGE, true);
 #if 0


### PR DESCRIPTION
... as they break access to some old SMBv1 servers.