### PR TITLE
exit_process.h: fix handling of SIGINT and SIGTERM (fixes #1219)

### DIFF
--- a/winsup/cygwin/include/cygwin/exit_process.h
+++ b/winsup/cygwin/include/cygwin/exit_process.h
@@ -14,16 +14,56 @@
 
 #include <tlhelp32.h>
 
+static int
+terminate_process_with_remote_thread(HANDLE process, int exit_code)
+{
+  static LPTHREAD_START_ROUTINE exit_process_address;
+  if (!exit_process_address)
+    {
+      HINSTANCE kernel32 = GetModuleHandle ("kernel32");
+      exit_process_address = (LPTHREAD_START_ROUTINE)
+        GetProcAddress (kernel32, "ExitProcess");
+    }
+  DWORD thread_id;
+  HANDLE thread = !exit_process_address ? NULL :
+    CreateRemoteThread (process, NULL, 0, exit_process_address,
+                      (PVOID)exit_code, 0, &thread_id);
+
+  if (thread)
+    {
+      CloseHandle (thread);
+      /*
+      * Wait 10 seconds (arbitrary constant) for the process to
+      * finish; After that grace period, fall back to terminating
+      * non-gently.
+      */
+      if (WaitForSingleObject (process, 10000) == WAIT_OBJECT_0)
+        return 0;
+    }
+
+  return -1;
+}
+
 /**
- * Terminates the process corresponding to the process ID and all of its
- * directly and indirectly spawned subprocesses.
+ * Terminates the process corresponding to the process ID
  *
- * This way of terminating the processes is not gentle: the processes get
- * no chance of cleaning up after themselves (closing file handles, removing
+ * This way of terminating the processes is not gentle: the process gets
+ * no chance of cleaning up after itself (closing file handles, removing
  * .lock files, terminating spawned processes (if any), etc).
  */
 static int
-terminate_process_tree(HANDLE main_process, int exit_code)
+terminate_process(HANDLE process, int exit_code)
+{
+  return int(TerminateProcess (process, exit_code));
+}
+
+/**
+ * Terminates the process corresponding to the process ID and all of its
+ * directly and indirectly spawned subprocesses using the provided
+ * terminate callback function
+ */
+static int
+terminate_process_tree(HANDLE main_process, int exit_code, int (*terminate)(HANDLE, int))
 {
   HANDLE snapshot = CreateToolhelp32Snapshot (TH32CS_SNAPPROCESS, 0);
   PROCESSENTRY32 entry;
@@ -46,6 +86,7 @@ terminate_process_tree(HANDLE main_process, int exit_code)
   for (;;)
     {
       int orig_len = len;
+      pid_t cyg_pid;
 
       memset (&entry, 0, sizeof (entry));
       entry.dwSize = sizeof (entry);
@@ -57,6 +98,12 @@ terminate_process_tree(HANDLE main_process, int exit_code)
         {
           for (i = len - 1; i >= 0; i--)
             {
+              cyg_pid = cygwin_winpid_to_pid(entry.th32ProcessID);
+              if (cyg_pid > -1)
+                {
+                  kill(cyg_pid, exit_code);
+                  continue;
+                }
               if (pids[i] == entry.th32ProcessID)
                 break;
               if (pids[i] == entry.th32ParentProcessID)
@@ -76,7 +123,7 @@ terminate_process_tree(HANDLE main_process, int exit_code)
 
       if (process)
         {
-          if (!TerminateProcess (process, exit_code))
+          if (!(*terminate) (process, exit_code))
             ret = -1;
           CloseHandle (process);
         }
@@ -129,39 +176,10 @@ exit_process(HANDLE process, int exit_code)
 
   if (GetExitCodeProcess (process, &code) && code == STILL_ACTIVE)
     {
-      /*
-       * We cannot determine the address of ExitProcess() for a process
-       * that does not match the current architecture (e.g. for a 32-bit
-       * process when we're running in 64-bit mode).
-       */
-      if (process_architecture_matches_current (process))
-        {
-          static LPTHREAD_START_ROUTINE exit_process_address;
-          if (!exit_process_address)
-            {
-              HINSTANCE kernel32 = GetModuleHandle ("kernel32");
-              exit_process_address = (LPTHREAD_START_ROUTINE)
-                GetProcAddress (kernel32, "ExitProcess");
-            }
-          DWORD thread_id;
-          HANDLE thread = !exit_process_address ? NULL :
-            CreateRemoteThread (process, NULL, 0, exit_process_address,
-                                (PVOID)exit_code, 0, &thread_id);
+      if (process_architecture_matches_current(process) && (exit_code == SIGINT || exit_code == SIGTERM))
+        return terminate_process_tree (process, exit_code, terminate_process_with_remote_thread);
 
-          if (thread)
-            {
-              CloseHandle (thread);
-              /*
-               * Wait 10 seconds (arbitrary constant) for the process to
-               * finish; After that grace period, fall back to terminating
-               * non-gently.
-               */
-              if (WaitForSingleObject (process, 10000) == WAIT_OBJECT_0)
-                return 0;
-            }
-        }
-
-      return terminate_process_tree (process, exit_code);
+      return terminate_process_tree (process, exit_code, terminate_process);
     }
 
   return -1;


### PR DESCRIPTION
Handle SIGINT and SIGTERM by injecting into the process
a thread that runs ExitProcess. Use TerminateProcess otherwise.

Signed-off-by: Adam Smith <afsmith92@gmail.com>