### PR TITLE
Fix incorrect path conversion (trailing slash)

### DIFF
--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -685,7 +685,7 @@ void posix_to_win32_path(const char* from, const char* to, char** dst, const cha
         strncpy(one_path, from, to-from);
         one_path[to-from] = '\0';
 
-        path_conv conv (one_path, 0);
+        path_conv conv (one_path, PC_KEEP_FINAL_SLASH);
         if (conv.error)
         {
           set_errno(conv.error);

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -1237,7 +1237,21 @@ path_conv::check (const char *src, unsigned opt,
 		  this->modifiable_path ()[n] = '\\';
 		  this->modifiable_path ()[n + 1] = '\0';
 		}
+	      need_directory = 0;
 	    }
+	}
+
+      if ((opt & PC_KEEP_FINAL_SLASH) && need_directory)
+	{
+	  size_t n = strlen (this->path);
+	  /* Do not add trailing \ to UNC device names like \\.\a: */
+	  if (this->path[n - 1] != '\\' &&
+	      (strncmp (this->path, "\\\\.\\", 4) != 0))
+	    {
+	      this->modifiable_path ()[n] = '\\';
+	      this->modifiable_path ()[n + 1] = '\0';
+	    }
+	  need_directory = 0;
 	}
 
       if (saw_symlinks)

--- a/winsup/cygwin/path.h
+++ b/winsup/cygwin/path.h
@@ -51,6 +51,7 @@ enum pathconv_arg
   PC_NOWARN		= 0x0100,
   PC_OPEN		= 0x0200,	/* use open semantics */
   PC_CTTY		= 0x0400,	/* could later be used as ctty */
+  PC_KEEP_FINAL_SLASH	= 0x0800,
   PC_KEEP_HANDLE	= 0x00400000,
   PC_NO_ACCESS_CHECK	= 0x00800000
 };


### PR DESCRIPTION
This is intended to be squashed into 50159fe297ca46145558b60a0354701e3ce1bb54.

The problem with the original approach is not that it is completely
bogus. After all, when you pass the option --prefix=/tmp/ to Git, you do
want to end up with a trailing slash.

The real problem with the original approach is that it simply changed
path_conv, completely obvlivious and careless about other users of
path_conv.

That was really wrong, of course, and cost us time, sweat and tears. The
appropriate approach is to *not* affect other users, but instead
introduce a flag that we use in *our* caller, so that everybody gets
what they want:

- emulation of inodes on FAT by calculating the hash on the normalized
  path: works.

- MSYS2's conversion of "POSIX" paths to Windows paths: works.