### PR TITLE
Fix encoding for (non-MSYS) console programs heeding `LC_ALL`

### DIFF
--- a/winsup/cygwin/fhandler_tty.cc
+++ b/winsup/cygwin/fhandler_tty.cc
@@ -2905,6 +2905,8 @@ fhandler_pty_slave::setup_locale (void)
 	  get_ttyp ()->term_code_page = cs_names[i].cp;
 	  break;
 	}
+  SetConsoleCP (get_ttyp ()->term_code_page);
+  SetConsoleOutputCP (get_ttyp ()->term_code_page);
 }
 
 void


### PR DESCRIPTION
This is a companion PR to https://github.com/msys2/msys2-runtime/pull/15.