### PR TITLE
Allow running the Windows Store version of Python3

### DIFF
--- a/winsup/cygwin/ntdll.h
+++ b/winsup/cygwin/ntdll.h
@@ -1423,6 +1423,12 @@ extern "C"
   NTSTATUS NTAPI NtMapViewOfSection (HANDLE, HANDLE, PVOID *, ULONG_PTR, SIZE_T,
 				     PLARGE_INTEGER, PSIZE_T, SECTION_INHERIT,
 				     ULONG, ULONG);
+
+/* For the extended memory API. */
+#if __MINGW64_VERSION_MAJOR < 8
+#error "Version >= 8 of the w32api headers is required"
+#endif
+
   NTSTATUS NTAPI NtMapViewOfSectionEx (HANDLE, HANDLE, PVOID *, PLARGE_INTEGER,
 				       PSIZE_T, ULONG, ULONG,
 				       PMEM_EXTENDED_PARAMETER, ULONG);

--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -2439,6 +2439,22 @@ symlink_info::check_sysfile (HANDLE h)
   return res;
 }
 
+typedef struct _REPARSE_APPEXECLINK_BUFFER
+{
+  DWORD ReparseTag;
+  WORD  ReparseDataLength;
+  WORD  Reserved;
+  struct {
+    DWORD Version;       /* Take member name with a grain of salt. */
+    WCHAR Strings[1];    /* Four serialized, NUL-terminated WCHAR strings:
+			   - Package ID
+			   - Entry Point
+			   - Executable Path
+			   - Application Type
+			   We're only interested in the Executable Path */
+  } AppExecLinkReparseBuffer;
+} REPARSE_APPEXECLINK_BUFFER,*PREPARSE_APPEXECLINK_BUFFER;
+
 static bool
 check_reparse_point_string (PUNICODE_STRING subst)
 {
@@ -2537,6 +2553,30 @@ check_reparse_point_target (HANDLE h, bool remote, PREPARSE_DATA_BUFFER rp,
 	}
       if (check_reparse_point_string (psymbuf))
 	return PATH_SYMLINK | PATH_REP;
+    }
+  else if (!remote && rp->ReparseTag == IO_REPARSE_TAG_APPEXECLINK)
+    {
+      /* App execution aliases are commonly used by Windows Store apps. */
+      PREPARSE_APPEXECLINK_BUFFER rpl = (PREPARSE_APPEXECLINK_BUFFER) rp;
+      WCHAR *buf = rpl->AppExecLinkReparseBuffer.Strings;
+      DWORD size = rp->ReparseDataLength / sizeof (WCHAR), n;
+
+      /* It seems that app execution aliases have a payload of four
+	 NUL-separated wide string: package id, entry point, executable
+	 and application type. We're interested in the executable. */
+      for (int i = 0; i < 3 && size > 0; i++)
+	{
+	  n = wcsnlen (buf, size - 1);
+	  if (i == 2 && n > 0 && n < size)
+	    {
+	      RtlInitCountedUnicodeString (psymbuf, buf, n * sizeof (WCHAR));
+	      return PATH_SYMLINK | PATH_REP;
+	    }
+	  if (i == 2)
+	    break;
+	  buf += n + 1;
+	  size -= n + 1;
+	}
     }
   else if (rp->ReparseTag == IO_REPARSE_TAG_LX_SYMLINK)
     {

--- a/winsup/cygwin/spawn.cc
+++ b/winsup/cygwin/spawn.cc
@@ -1166,6 +1166,13 @@ av::setup (const char *prog_arg, path_conv& real_path, const char *ext,
 			     FILE_SYNCHRONOUS_IO_NONALERT
 			     | FILE_OPEN_FOR_BACKUP_INTENT
 			     | FILE_NON_DIRECTORY_FILE);
+	if (status == STATUS_IO_REPARSE_TAG_NOT_HANDLED)
+	  {
+	    /* This is most likely an app execution alias (such as the
+	       Windows Store version of Python, i.e. not a Cygwin program */
+	    real_path.set_cygexec (false);
+	    break;
+	  }
 	if (!NT_SUCCESS (status))
 	  {
 	    /* File is not readable?  Doesn't mean it's not executable.

--- a/winsup/cygwin/winlean.h
+++ b/winsup/cygwin/winlean.h
@@ -99,47 +99,17 @@ details. */
 extern "C" {
 #endif
 
-/* Define extended memory API here as long as not available from mingw-w64. */
+/* For the extended memory API. */
+#if __MINGW64_VERSION_MAJOR < 8
+#error "Version >= 8 of the w32api headers is required"
+#endif
 
-typedef struct _MEM_ADDRESS_REQUIREMENTS
-{
-  PVOID LowestStartingAddress;
-  PVOID HighestEndingAddress;
-  SIZE_T Alignment;
-} MEM_ADDRESS_REQUIREMENTS, *PMEM_ADDRESS_REQUIREMENTS;
-
-typedef enum MEM_EXTENDED_PARAMETER_TYPE
-{
-  MemExtendedParameterInvalidType = 0,
-  MemExtendedParameterAddressRequirements,
-  MemExtendedParameterNumaNode,
-  MemExtendedParameterPartitionHandle,
-  MemExtendedParameterUserPhysicalHandle,
-  MemExtendedParameterAttributeFlags,
-  MemExtendedParameterMax
-} MEM_EXTENDED_PARAMETER_TYPE, *PMEM_EXTENDED_PARAMETER_TYPE;
-
-#define MEM_EXTENDED_PARAMETER_TYPE_BITS 8
-
-typedef struct DECLSPEC_ALIGN(8) MEM_EXTENDED_PARAMETER
-{
-  struct
-  {
-      DWORD64 Type : MEM_EXTENDED_PARAMETER_TYPE_BITS;
-      DWORD64 Reserved : 64 - MEM_EXTENDED_PARAMETER_TYPE_BITS;
-  };
-  union
-  {
-      DWORD64 ULong64;
-      PVOID Pointer;
-      SIZE_T Size;
-      HANDLE Handle;
-      DWORD ULong;
-  };
-} MEM_EXTENDED_PARAMETER, *PMEM_EXTENDED_PARAMETER;
-
-PVOID VirtualAlloc2 (HANDLE, PVOID, SIZE_T, ULONG, ULONG,
-		     PMEM_EXTENDED_PARAMETER, ULONG);
+/* VirtualAlloc2 is declared in <w32api/memoryapi.h> if NTDDI_VERSION
+   >= NTDDI_WIN10_RS4 (a compile-time condition).  But we need the
+   declaration unconditionally, even though the function will only be
+   executed on systems that support it (a run-time condition). */
+PVOID WINAPI VirtualAlloc2 (HANDLE, PVOID, SIZE_T, ULONG, ULONG,
+			    PMEM_EXTENDED_PARAMETER, ULONG);
 
 #ifdef __cplusplus
 }

--- a/winsup/utils/cygpath.cc
+++ b/winsup/utils/cygpath.cc
@@ -24,7 +24,6 @@ details. */
 #define _WIN32_WINNT 0x0a00
 #define WINVER 0x0a00
 #define NOCOMATTRIBUTE
-#define PMEM_EXTENDED_PARAMETER PVOID
 #include <windows.h>
 #include <userenv.h>
 #include <shlobj.h>

--- a/winsup/utils/ps.cc
+++ b/winsup/utils/ps.cc
@@ -6,7 +6,6 @@ This software is a copyrighted work licensed under the terms of the
 Cygwin license.  Please consult the file "CYGWIN_LICENSE" for
 details. */
 
-#define PMEM_EXTENDED_PARAMETER PVOID
 #include <errno.h>
 #include <stdio.h>
 #include <locale.h>


### PR DESCRIPTION
This backports 2533912fc7, 0631c6644e and c1f7c4d1b6. The former two teach Cygwin to handle the "app execution aliases" used by Windows Store, and the latter allows compiling with a current version of `mingw-w64-headers`.