### PR TITLE
FAST_CWD: adjust the initial search scope

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -4670,7 +4670,7 @@ find_fast_cwd_pointer ()
   if (!get_dir || !ent_crit)
     return NULL;
   /* Search first relative call instruction in RtlGetCurrentDirectory_U. */
-  const uint8_t *rcall = (const uint8_t *) memchr (get_dir, 0xe8, 80);
+  const uint8_t *rcall = (const uint8_t *) memchr (get_dir, 0xe8, 160);
   if (!rcall)
     return NULL;
   /* Fetch offset from instruction and compute address of called function.
@@ -4769,7 +4769,7 @@ find_fast_cwd_pointer ()
   if (!get_dir || !ent_crit)
     return NULL;
   /* Search first relative call instruction in RtlGetCurrentDirectory_U. */
-  const uint8_t *rcall = (const uint8_t *) memchr (get_dir, 0xe8, 64);
+  const uint8_t *rcall = (const uint8_t *) memchr (get_dir, 0xe8, 128);
   if (!rcall)
     return NULL;
   /* Fetch offset from instruction and compute address of called function.


### PR DESCRIPTION
based on #5fe6d81012e97a348608511450f6a63750c906b6