### PR TITLE
Route "Device Status Report" responses correctly

### DIFF
--- a/winsup/cygwin/fhandler_tty.cc
+++ b/winsup/cygwin/fhandler_tty.cc
@@ -1153,7 +1153,11 @@ fhandler_pty_slave::reset_switch_to_pcon (void)
 		    {
 		      char pipe[MAX_PATH];
 		      __small_sprintf (pipe,
+#ifdef __MSYS__
+			       "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
+#else
 			       "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
+#endif
 			       &cygheap->installation_key, get_minor ());
 		      pipe_request req = { GetCurrentProcessId () };
 		      pipe_reply repl;
@@ -3738,7 +3742,11 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
     {
       char pipe[MAX_PATH];
       __small_sprintf (pipe,
+#ifdef __MSYS__
+		       "\\\\.\\pipe\\msys-%S-pty%d-master-ctl",
+#else
 		       "\\\\.\\pipe\\cygwin-%S-pty%d-master-ctl",
+#endif
 		       &cygheap->installation_key, ttyp->get_minor ());
       pipe_request req = { GetCurrentProcessId () };
       pipe_reply repl;

--- a/winsup/cygwin/fhandler_tty.cc
+++ b/winsup/cygwin/fhandler_tty.cc
@@ -1247,10 +1247,13 @@ fhandler_pty_slave::mask_switch_to_pcon_in (bool mask, bool xfer)
   else if (InterlockedDecrement (&num_reader) == 0)
     CloseHandle (slave_reading);
 
+  bool need_xfer =
+    get_ttyp ()->switch_to_pcon_in && !get_ttyp ()->pcon_activated;
+
   /* In GDB, transfer input based on setpgid() does not work because
      GDB may not set terminal process group properly. Therefore,
      transfer input here if isHybrid is set. */
-  if (isHybrid && !!masked != mask && xfer
+  if ((isHybrid || need_xfer) && !!masked != mask && xfer
       && GetStdHandle (STD_INPUT_HANDLE) == get_handle ())
     {
       if (mask && get_ttyp ()->pcon_input_state_eq (tty::to_nat))
@@ -1544,7 +1547,7 @@ out:
   if (ptr0)
     { /* Not tcflush() */
       bool saw_eol = totalread > 0 && strchr ("\r\n", ptr0[totalread -1]);
-      mask_switch_to_pcon_in (false, saw_eol);
+      mask_switch_to_pcon_in (false, saw_eol || len == 0);
     }
 }
 
@@ -2224,6 +2227,15 @@ fhandler_pty_master::write (const void *ptr, size_t len)
       ReleaseMutex (input_mutex);
 
       return len;
+    }
+
+  if (to_be_read_from_pcon () && !get_ttyp ()->pcon_activated
+      && get_ttyp ()->pcon_input_state == tty::to_cyg)
+    {
+      WaitForSingleObject (input_mutex, INFINITE);
+      fhandler_pty_slave::transfer_input (tty::to_nat, from_master,
+					  get_ttyp (), input_available_event);
+      ReleaseMutex (input_mutex);
     }
 
   line_edit_status status = line_edit (p, len, ti, &ret);


### PR DESCRIPTION
A bug in the Cygwin/MSYS2 runtime sometimes caused responses to a `CSI [ 6n` request to be routed to the terminal instead of the process that requested it, causing strange characters to be "ghost-typed" e.g. after closing `vim` when calling `git config -e`.

The regression was actually introduced into v3.2.0, but not noticed earlier. [I reported the issue](https://sourceware.org/pipermail/cygwin-patches/2021q4/011587.html) after trying to figure out a workaround for three days, without success, and the original author of the commit introducing the regression provided a patch that works around it. I do not yet understand the patch, but let's take it for now, because this is a big blocker: we would not be able to release a new Git for Windows version even if we wanted because of this regression.

This fixes https://github.com/git-for-windows/git/issues/3579

While at it, also include a fixup that handles two previously unhandled instances of the `cygwin-pty` pipe (which is renamed to `msys-pty` in MSYS2) that I spotted while working on this bug.