### PR TITLE
Workaround certain anti-malware programs

### DIFF
--- a/winsup/cygwin/x86_64.din
+++ b/winsup/cygwin/x86_64.din
@@ -1,4 +1,4 @@
-LIBRARY "msys-2.0.dll" BASE=0x180040000
+LIBRARY "msys-2.0.dll" BASE=0x210040000
 
 EXPORTS
 #Exported variables


### PR DESCRIPTION
This might break things, but it turns out several Windows libraries like to be loaded at 0x180000000.

This causes a problem, because `msys-2.0.dll` loads at `0x180040000` and expects `0x180000000-0x180040000` to be available.
A problem arises when Antiviruses (or other DLL hooking mechanisms) load a dll whose preferred load address is `0x180000000` and fits in size before `0x180010000`:

1. `msys-2.0.dll` loads and fills `0x180010000-0x180040000` assuming no shared console structure is going to be needed.
2. Another dll loads and fills `0x180000000-0x18000xxxx`
3. `msys-2.0.dll` tries to load `0x180000000-0x180010000` but it's not available. It falls back to another address, but down the line something else fails.

This bug triggers when using subshells (e.g.: `git clone --recursive`).

(I guess msys should be able to work around the address conflict, but the code is failing in some way and I'm having a hard time figuring it out, so...)

This addresses git-for-windows/git#3539