### PR TITLE
Add a work-around for that overzealous pseudo console code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           msystem: MSYS
           update: true
-          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel
+          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel xmlto docbook-xsl
 
       - name: Build
         shell: msys2 {0}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           msystem: MSYS
           update: true
-          install: msys2-devel base-devel cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel
+          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel
 
       - name: Build
         shell: msys2 {0}

--- a/winsup/cygwin/fhandler_console.cc
+++ b/winsup/cygwin/fhandler_console.cc
@@ -476,6 +476,11 @@ fhandler_console::set_input_mode (tty::cons_mode m, const termios *t,
   DWORD flags = 0, oflags;
   WaitForSingleObject (p->input_mutex, INFINITE);
   GetConsoleMode (p->input_handle, &oflags);
+  if (disable_pcon && m == tty::cygwin)
+    /* If we disabled pseudo console support explicitly, it would be wrong to
+       mess with the flags. In fact, we _still_ mess with the flags, but at
+       least with tty::restore we do little damage. */
+    m = tty::restore;
   switch (m)
     {
     case tty::restore:


### PR DESCRIPTION
We tried to address the problem in the Git for Windows project that we are facing with the pseudo console code that made it into the Cygwin runtime, by defaulting to `MSYS=disable_pcon`. That code simply won't stabilize, and bugs are still found every couple of weeks, and they are really, really, really hard to debug because the code in question is quite the logical labyrinth.

If we thought that `MSYS=disable_pcon` was enough, we were in for a nasty surprise. The pseudo console code did not try to leave the original code paths as intact as possible when the pseudo console support was disabled. Oh no. Quite to the contrary. It changed pretty much everything. With the bugs you might expect _even_ if disabling support for pseudo consoles.

In this instance, the Cygwin runtime (and hence the MSYS2 runtime, too), messes with the Console mode so much that things stop working, except Cygwin programs (or in our case, MSYS).

Here is a surgical work-around for _this specific issue_. I dare not go further, not only because it costs _so_ much time to read through that code and try to make sense of it, but also because the code flow is so unclear that it is really, really, really easy to break anything even if that was not the intention.
 
This fixes https://github.com/GitCredentialManager/git-credential-manager/issues/576 (for some definition of "fixes").