### PR TITLE
posix_spawn: fix get/set uid/gid calls for 32 bit

### DIFF
--- a/newlib/libc/posix/posix_spawn.c
+++ b/newlib/libc/posix/posix_spawn.c
@@ -146,6 +146,17 @@ typedef struct __posix_spawn_file_actions_entry {
  * Spawn routines
  */
 
+#if defined (__CYGWIN__) && defined (__i386__)
+extern int getgid32 (void);
+extern int getuid32 (void);
+extern int setegid32 (gid_t egid);
+extern int seteuid32 (uid_t euid);
+#define setegid setegid32
+#define seteuid seteuid32
+#define getgid getgid32
+#define getuid getuid32
+#endif
+
 static int
 process_spawnattr(const posix_spawnattr_t sa)
 {


### PR DESCRIPTION
This is a companion to https://github.com/msys2/msys2-runtime/pull/80. It is technically not needed right now, but I'd like to rebuild Git for Windows' `msys2-runtime` after https://github.com/git-for-windows/build-extra/commit/dd84713c077b12c1f2ae879144154fd852e16630, anyway, so this presents a fine excuse to do so.

This addresses https://github.com/git-for-windows/git/issues/3630.