### PR TITLE
Implicitly support the /dev/fd symlink and friends

### DIFF
--- a/winsup/cygwin/Makefile.am
+++ b/winsup/cygwin/Makefile.am
@@ -230,6 +230,7 @@ DLL_FILES= \
 	fhandler_console.cc \
 	fhandler_cygdrive.cc \
 	fhandler_dev.cc \
+	fhandler_dev_fd.cc \
 	fhandler_disk_file.cc \
 	fhandler_dsp.cc \
 	fhandler_fifo.cc \

--- a/winsup/cygwin/devices.cc
+++ b/winsup/cygwin/devices.cc
@@ -300,6 +300,7 @@ const _RDATA _device dev_storage[] =
   {"/dev/cons127", BRACK(FHDEV(DEV_CONS_MAJOR, 127)), "/dev/cons127", exists_console, S_IFCHR, true},
   {"/dev/console", BRACK(FH_CONSOLE), "/dev/console", exists_console, S_IFCHR, true},
   {"/dev/dsp", BRACK(FH_OSS_DSP), "\\Device\\Null", exists_ntdev, S_IFCHR, true},
+  {"/dev/fd", BRACK(FH_DEV_FD), "/proc/self/fd", exists, S_IFLNK, true},
   {"/dev/fd0", BRACK(FHDEV(DEV_FLOPPY_MAJOR, 0)), "\\Device\\Floppy0", exists_ntdev, S_IFBLK, true},
   {"/dev/fd1", BRACK(FHDEV(DEV_FLOPPY_MAJOR, 1)), "\\Device\\Floppy1", exists_ntdev, S_IFBLK, true},
   {"/dev/fd2", BRACK(FHDEV(DEV_FLOPPY_MAJOR, 2)), "\\Device\\Floppy2", exists_ntdev, S_IFBLK, true},
@@ -736,6 +737,9 @@ const _RDATA _device dev_storage[] =
   {"/dev/st125", BRACK(FHDEV(DEV_TAPE_MAJOR, 125)), "\\Device\\Tape125", exists_ntdev, S_IFBLK, true},
   {"/dev/st126", BRACK(FHDEV(DEV_TAPE_MAJOR, 126)), "\\Device\\Tape126", exists_ntdev, S_IFBLK, true},
   {"/dev/st127", BRACK(FHDEV(DEV_TAPE_MAJOR, 127)), "\\Device\\Tape127", exists_ntdev, S_IFBLK, true},
+  {"/dev/stderr", BRACK(FH_DEV_FD), "/proc/self/fd/2", exists, S_IFLNK, true},
+  {"/dev/stdin", BRACK(FH_DEV_FD), "/proc/self/fd/0", exists, S_IFLNK, true},
+  {"/dev/stdout", BRACK(FH_DEV_FD), "/proc/self/fd/1", exists, S_IFLNK, true},
   {"/dev/tty", BRACK(FH_TTY), "/dev/tty", exists, S_IFCHR, true},
   {"/dev/ttyS0", BRACK(FHDEV(DEV_SERIAL_MAJOR, 0)), "\\??\\COM1", exists_ntdev, S_IFCHR, true},
   {"/dev/ttyS1", BRACK(FHDEV(DEV_SERIAL_MAJOR, 1)), "\\??\\COM2", exists_ntdev, S_IFCHR, true},
@@ -1002,9 +1006,9 @@ const _RDATA _device dev_storage[] =
 
 const _device *cons_dev = dev_storage + 20;
 const _device *console_dev = dev_storage + 148;
-const _device *ptym_dev = dev_storage + 720;
-const _device *ptys_dev = dev_storage + 297;
-const _device *urandom_dev = dev_storage + 715;
+const _device *ptym_dev = dev_storage + 724;
+const _device *ptys_dev = dev_storage + 298;
+const _device *urandom_dev = dev_storage + 719;
 
 
 static KR_device_t KR_find_keyword (const char *KR_keyword, int KR_length)
@@ -1034,7 +1038,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":pipe", 5) == 0)
             {
 {
-return dev_storage + 719;
+return dev_storage + 723;
 
 }
             }
@@ -1049,7 +1053,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":fifo", 5) == 0)
             {
 {
-return dev_storage + 718;
+return dev_storage + 722;
 
 }
             }
@@ -1073,7 +1077,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym9", 6) == 0)
             {
 {
-return dev_storage + 729;
+return dev_storage + 733;
 
 }
             }
@@ -1088,7 +1092,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym8", 6) == 0)
             {
 {
-return dev_storage + 728;
+return dev_storage + 732;
 
 }
             }
@@ -1103,7 +1107,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym7", 6) == 0)
             {
 {
-return dev_storage + 727;
+return dev_storage + 731;
 
 }
             }
@@ -1118,7 +1122,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym6", 6) == 0)
             {
 {
-return dev_storage + 726;
+return dev_storage + 730;
 
 }
             }
@@ -1133,7 +1137,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym5", 6) == 0)
             {
 {
-return dev_storage + 725;
+return dev_storage + 729;
 
 }
             }
@@ -1148,7 +1152,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym4", 6) == 0)
             {
 {
-return dev_storage + 724;
+return dev_storage + 728;
 
 }
             }
@@ -1163,7 +1167,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym3", 6) == 0)
             {
 {
-return dev_storage + 723;
+return dev_storage + 727;
 
 }
             }
@@ -1178,7 +1182,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym2", 6) == 0)
             {
 {
-return dev_storage + 722;
+return dev_storage + 726;
 
 }
             }
@@ -1193,7 +1197,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym1", 6) == 0)
             {
 {
-return dev_storage + 721;
+return dev_storage + 725;
 
 }
             }
@@ -1208,7 +1212,7 @@ return	NULL;
           if (strncmp (KR_keyword, ":ptym0", 6) == 0)
             {
 {
-return dev_storage + 720;
+return dev_storage + 724;
 
 }
             }
@@ -1228,6 +1232,21 @@ return	NULL;
     case 7:
       switch (KR_keyword [5])
         {
+        case 'f':
+          if (strncmp (KR_keyword, "/dev/fd", 7) == 0)
+            {
+{
+return dev_storage + 150;
+
+}
+            }
+          else
+            {
+{
+return	NULL;
+
+}
+            }
         case '9':
           switch (KR_keyword [6])
             {
@@ -1235,7 +1254,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym99", 7) == 0)
                 {
 {
-return dev_storage + 819;
+return dev_storage + 823;
 
 }
                 }
@@ -1250,7 +1269,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym98", 7) == 0)
                 {
 {
-return dev_storage + 818;
+return dev_storage + 822;
 
 }
                 }
@@ -1265,7 +1284,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym97", 7) == 0)
                 {
 {
-return dev_storage + 817;
+return dev_storage + 821;
 
 }
                 }
@@ -1280,7 +1299,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym96", 7) == 0)
                 {
 {
-return dev_storage + 816;
+return dev_storage + 820;
 
 }
                 }
@@ -1295,7 +1314,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym95", 7) == 0)
                 {
 {
-return dev_storage + 815;
+return dev_storage + 819;
 
 }
                 }
@@ -1310,7 +1329,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym94", 7) == 0)
                 {
 {
-return dev_storage + 814;
+return dev_storage + 818;
 
 }
                 }
@@ -1325,7 +1344,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym93", 7) == 0)
                 {
 {
-return dev_storage + 813;
+return dev_storage + 817;
 
 }
                 }
@@ -1340,7 +1359,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym92", 7) == 0)
                 {
 {
-return dev_storage + 812;
+return dev_storage + 816;
 
 }
                 }
@@ -1355,7 +1374,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym91", 7) == 0)
                 {
 {
-return dev_storage + 811;
+return dev_storage + 815;
 
 }
                 }
@@ -1370,7 +1389,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym90", 7) == 0)
                 {
 {
-return dev_storage + 810;
+return dev_storage + 814;
 
 }
                 }
@@ -1394,7 +1413,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym89", 7) == 0)
                 {
 {
-return dev_storage + 809;
+return dev_storage + 813;
 
 }
                 }
@@ -1409,7 +1428,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym88", 7) == 0)
                 {
 {
-return dev_storage + 808;
+return dev_storage + 812;
 
 }
                 }
@@ -1424,7 +1443,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym87", 7) == 0)
                 {
 {
-return dev_storage + 807;
+return dev_storage + 811;
 
 }
                 }
@@ -1439,7 +1458,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym86", 7) == 0)
                 {
 {
-return dev_storage + 806;
+return dev_storage + 810;
 
 }
                 }
@@ -1454,7 +1473,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym85", 7) == 0)
                 {
 {
-return dev_storage + 805;
+return dev_storage + 809;
 
 }
                 }
@@ -1469,7 +1488,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym84", 7) == 0)
                 {
 {
-return dev_storage + 804;
+return dev_storage + 808;
 
 }
                 }
@@ -1484,7 +1503,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym83", 7) == 0)
                 {
 {
-return dev_storage + 803;
+return dev_storage + 807;
 
 }
                 }
@@ -1499,7 +1518,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym82", 7) == 0)
                 {
 {
-return dev_storage + 802;
+return dev_storage + 806;
 
 }
                 }
@@ -1514,7 +1533,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym81", 7) == 0)
                 {
 {
-return dev_storage + 801;
+return dev_storage + 805;
 
 }
                 }
@@ -1529,7 +1548,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym80", 7) == 0)
                 {
 {
-return dev_storage + 800;
+return dev_storage + 804;
 
 }
                 }
@@ -1553,7 +1572,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym79", 7) == 0)
                 {
 {
-return dev_storage + 799;
+return dev_storage + 803;
 
 }
                 }
@@ -1568,7 +1587,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym78", 7) == 0)
                 {
 {
-return dev_storage + 798;
+return dev_storage + 802;
 
 }
                 }
@@ -1583,7 +1602,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym77", 7) == 0)
                 {
 {
-return dev_storage + 797;
+return dev_storage + 801;
 
 }
                 }
@@ -1598,7 +1617,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym76", 7) == 0)
                 {
 {
-return dev_storage + 796;
+return dev_storage + 800;
 
 }
                 }
@@ -1613,7 +1632,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym75", 7) == 0)
                 {
 {
-return dev_storage + 795;
+return dev_storage + 799;
 
 }
                 }
@@ -1628,7 +1647,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym74", 7) == 0)
                 {
 {
-return dev_storage + 794;
+return dev_storage + 798;
 
 }
                 }
@@ -1643,7 +1662,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym73", 7) == 0)
                 {
 {
-return dev_storage + 793;
+return dev_storage + 797;
 
 }
                 }
@@ -1658,7 +1677,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym72", 7) == 0)
                 {
 {
-return dev_storage + 792;
+return dev_storage + 796;
 
 }
                 }
@@ -1673,7 +1692,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym71", 7) == 0)
                 {
 {
-return dev_storage + 791;
+return dev_storage + 795;
 
 }
                 }
@@ -1688,7 +1707,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym70", 7) == 0)
                 {
 {
-return dev_storage + 790;
+return dev_storage + 794;
 
 }
                 }
@@ -1712,7 +1731,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym69", 7) == 0)
                 {
 {
-return dev_storage + 789;
+return dev_storage + 793;
 
 }
                 }
@@ -1727,7 +1746,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym68", 7) == 0)
                 {
 {
-return dev_storage + 788;
+return dev_storage + 792;
 
 }
                 }
@@ -1742,7 +1761,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym67", 7) == 0)
                 {
 {
-return dev_storage + 787;
+return dev_storage + 791;
 
 }
                 }
@@ -1757,7 +1776,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym66", 7) == 0)
                 {
 {
-return dev_storage + 786;
+return dev_storage + 790;
 
 }
                 }
@@ -1772,7 +1791,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym65", 7) == 0)
                 {
 {
-return dev_storage + 785;
+return dev_storage + 789;
 
 }
                 }
@@ -1787,7 +1806,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym64", 7) == 0)
                 {
 {
-return dev_storage + 784;
+return dev_storage + 788;
 
 }
                 }
@@ -1802,7 +1821,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym63", 7) == 0)
                 {
 {
-return dev_storage + 783;
+return dev_storage + 787;
 
 }
                 }
@@ -1817,7 +1836,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym62", 7) == 0)
                 {
 {
-return dev_storage + 782;
+return dev_storage + 786;
 
 }
                 }
@@ -1832,7 +1851,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym61", 7) == 0)
                 {
 {
-return dev_storage + 781;
+return dev_storage + 785;
 
 }
                 }
@@ -1847,7 +1866,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym60", 7) == 0)
                 {
 {
-return dev_storage + 780;
+return dev_storage + 784;
 
 }
                 }
@@ -1871,7 +1890,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym59", 7) == 0)
                 {
 {
-return dev_storage + 779;
+return dev_storage + 783;
 
 }
                 }
@@ -1886,7 +1905,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym58", 7) == 0)
                 {
 {
-return dev_storage + 778;
+return dev_storage + 782;
 
 }
                 }
@@ -1901,7 +1920,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym57", 7) == 0)
                 {
 {
-return dev_storage + 777;
+return dev_storage + 781;
 
 }
                 }
@@ -1916,7 +1935,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym56", 7) == 0)
                 {
 {
-return dev_storage + 776;
+return dev_storage + 780;
 
 }
                 }
@@ -1931,7 +1950,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym55", 7) == 0)
                 {
 {
-return dev_storage + 775;
+return dev_storage + 779;
 
 }
                 }
@@ -1946,7 +1965,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym54", 7) == 0)
                 {
 {
-return dev_storage + 774;
+return dev_storage + 778;
 
 }
                 }
@@ -1961,7 +1980,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym53", 7) == 0)
                 {
 {
-return dev_storage + 773;
+return dev_storage + 777;
 
 }
                 }
@@ -1976,7 +1995,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym52", 7) == 0)
                 {
 {
-return dev_storage + 772;
+return dev_storage + 776;
 
 }
                 }
@@ -1991,7 +2010,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym51", 7) == 0)
                 {
 {
-return dev_storage + 771;
+return dev_storage + 775;
 
 }
                 }
@@ -2006,7 +2025,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym50", 7) == 0)
                 {
 {
-return dev_storage + 770;
+return dev_storage + 774;
 
 }
                 }
@@ -2030,7 +2049,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym49", 7) == 0)
                 {
 {
-return dev_storage + 769;
+return dev_storage + 773;
 
 }
                 }
@@ -2045,7 +2064,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym48", 7) == 0)
                 {
 {
-return dev_storage + 768;
+return dev_storage + 772;
 
 }
                 }
@@ -2060,7 +2079,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym47", 7) == 0)
                 {
 {
-return dev_storage + 767;
+return dev_storage + 771;
 
 }
                 }
@@ -2075,7 +2094,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym46", 7) == 0)
                 {
 {
-return dev_storage + 766;
+return dev_storage + 770;
 
 }
                 }
@@ -2090,7 +2109,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym45", 7) == 0)
                 {
 {
-return dev_storage + 765;
+return dev_storage + 769;
 
 }
                 }
@@ -2105,7 +2124,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym44", 7) == 0)
                 {
 {
-return dev_storage + 764;
+return dev_storage + 768;
 
 }
                 }
@@ -2120,7 +2139,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym43", 7) == 0)
                 {
 {
-return dev_storage + 763;
+return dev_storage + 767;
 
 }
                 }
@@ -2135,7 +2154,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym42", 7) == 0)
                 {
 {
-return dev_storage + 762;
+return dev_storage + 766;
 
 }
                 }
@@ -2150,7 +2169,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym41", 7) == 0)
                 {
 {
-return dev_storage + 761;
+return dev_storage + 765;
 
 }
                 }
@@ -2165,7 +2184,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym40", 7) == 0)
                 {
 {
-return dev_storage + 760;
+return dev_storage + 764;
 
 }
                 }
@@ -2189,7 +2208,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym39", 7) == 0)
                 {
 {
-return dev_storage + 759;
+return dev_storage + 763;
 
 }
                 }
@@ -2204,7 +2223,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym38", 7) == 0)
                 {
 {
-return dev_storage + 758;
+return dev_storage + 762;
 
 }
                 }
@@ -2219,7 +2238,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym37", 7) == 0)
                 {
 {
-return dev_storage + 757;
+return dev_storage + 761;
 
 }
                 }
@@ -2234,7 +2253,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym36", 7) == 0)
                 {
 {
-return dev_storage + 756;
+return dev_storage + 760;
 
 }
                 }
@@ -2249,7 +2268,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym35", 7) == 0)
                 {
 {
-return dev_storage + 755;
+return dev_storage + 759;
 
 }
                 }
@@ -2264,7 +2283,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym34", 7) == 0)
                 {
 {
-return dev_storage + 754;
+return dev_storage + 758;
 
 }
                 }
@@ -2279,7 +2298,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym33", 7) == 0)
                 {
 {
-return dev_storage + 753;
+return dev_storage + 757;
 
 }
                 }
@@ -2294,7 +2313,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym32", 7) == 0)
                 {
 {
-return dev_storage + 752;
+return dev_storage + 756;
 
 }
                 }
@@ -2309,7 +2328,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym31", 7) == 0)
                 {
 {
-return dev_storage + 751;
+return dev_storage + 755;
 
 }
                 }
@@ -2324,7 +2343,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym30", 7) == 0)
                 {
 {
-return dev_storage + 750;
+return dev_storage + 754;
 
 }
                 }
@@ -2348,7 +2367,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym29", 7) == 0)
                 {
 {
-return dev_storage + 749;
+return dev_storage + 753;
 
 }
                 }
@@ -2363,7 +2382,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym28", 7) == 0)
                 {
 {
-return dev_storage + 748;
+return dev_storage + 752;
 
 }
                 }
@@ -2378,7 +2397,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym27", 7) == 0)
                 {
 {
-return dev_storage + 747;
+return dev_storage + 751;
 
 }
                 }
@@ -2393,7 +2412,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym26", 7) == 0)
                 {
 {
-return dev_storage + 746;
+return dev_storage + 750;
 
 }
                 }
@@ -2408,7 +2427,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym25", 7) == 0)
                 {
 {
-return dev_storage + 745;
+return dev_storage + 749;
 
 }
                 }
@@ -2423,7 +2442,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym24", 7) == 0)
                 {
 {
-return dev_storage + 744;
+return dev_storage + 748;
 
 }
                 }
@@ -2438,7 +2457,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym23", 7) == 0)
                 {
 {
-return dev_storage + 743;
+return dev_storage + 747;
 
 }
                 }
@@ -2453,7 +2472,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym22", 7) == 0)
                 {
 {
-return dev_storage + 742;
+return dev_storage + 746;
 
 }
                 }
@@ -2468,7 +2487,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym21", 7) == 0)
                 {
 {
-return dev_storage + 741;
+return dev_storage + 745;
 
 }
                 }
@@ -2483,7 +2502,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym20", 7) == 0)
                 {
 {
-return dev_storage + 740;
+return dev_storage + 744;
 
 }
                 }
@@ -2507,7 +2526,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym19", 7) == 0)
                 {
 {
-return dev_storage + 739;
+return dev_storage + 743;
 
 }
                 }
@@ -2522,7 +2541,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym18", 7) == 0)
                 {
 {
-return dev_storage + 738;
+return dev_storage + 742;
 
 }
                 }
@@ -2537,7 +2556,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym17", 7) == 0)
                 {
 {
-return dev_storage + 737;
+return dev_storage + 741;
 
 }
                 }
@@ -2552,7 +2571,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym16", 7) == 0)
                 {
 {
-return dev_storage + 736;
+return dev_storage + 740;
 
 }
                 }
@@ -2567,7 +2586,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym15", 7) == 0)
                 {
 {
-return dev_storage + 735;
+return dev_storage + 739;
 
 }
                 }
@@ -2582,7 +2601,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym14", 7) == 0)
                 {
 {
-return dev_storage + 734;
+return dev_storage + 738;
 
 }
                 }
@@ -2597,7 +2616,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym13", 7) == 0)
                 {
 {
-return dev_storage + 733;
+return dev_storage + 737;
 
 }
                 }
@@ -2612,7 +2631,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym12", 7) == 0)
                 {
 {
-return dev_storage + 732;
+return dev_storage + 736;
 
 }
                 }
@@ -2627,7 +2646,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym11", 7) == 0)
                 {
 {
-return dev_storage + 731;
+return dev_storage + 735;
 
 }
                 }
@@ -2642,7 +2661,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym10", 7) == 0)
                 {
 {
-return dev_storage + 730;
+return dev_storage + 734;
 
 }
                 }
@@ -2672,7 +2691,7 @@ return	NULL;
           if (strncmp (KR_keyword, "/dev/tty", 8) == 0)
             {
 {
-return dev_storage + 586;
+return dev_storage + 590;
 
 }
             }
@@ -2705,7 +2724,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st9", 8) == 0)
                 {
 {
-return dev_storage + 467;
+return dev_storage + 468;
 
 }
                 }
@@ -2720,7 +2739,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr9", 8) == 0)
                 {
 {
-return dev_storage + 451;
+return dev_storage + 452;
 
 }
                 }
@@ -2735,7 +2754,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd9", 8) == 0)
                 {
 {
-return dev_storage + 159;
+return dev_storage + 160;
 
 }
                 }
@@ -2750,7 +2769,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym119", 8) == 0)
                 {
 {
-return dev_storage + 839;
+return dev_storage + 843;
 
 }
                 }
@@ -2765,7 +2784,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym109", 8) == 0)
                 {
 {
-return dev_storage + 829;
+return dev_storage + 833;
 
 }
                 }
@@ -2789,7 +2808,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st8", 8) == 0)
                 {
 {
-return dev_storage + 466;
+return dev_storage + 467;
 
 }
                 }
@@ -2804,7 +2823,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr8", 8) == 0)
                 {
 {
-return dev_storage + 450;
+return dev_storage + 451;
 
 }
                 }
@@ -2819,7 +2838,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd8", 8) == 0)
                 {
 {
-return dev_storage + 158;
+return dev_storage + 159;
 
 }
                 }
@@ -2834,7 +2853,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym118", 8) == 0)
                 {
 {
-return dev_storage + 838;
+return dev_storage + 842;
 
 }
                 }
@@ -2849,7 +2868,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym108", 8) == 0)
                 {
 {
-return dev_storage + 828;
+return dev_storage + 832;
 
 }
                 }
@@ -2873,7 +2892,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st7", 8) == 0)
                 {
 {
-return dev_storage + 465;
+return dev_storage + 466;
 
 }
                 }
@@ -2888,7 +2907,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr7", 8) == 0)
                 {
 {
-return dev_storage + 449;
+return dev_storage + 450;
 
 }
                 }
@@ -2903,7 +2922,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd7", 8) == 0)
                 {
 {
-return dev_storage + 157;
+return dev_storage + 158;
 
 }
                 }
@@ -2918,7 +2937,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym127", 8) == 0)
                 {
 {
-return dev_storage + 847;
+return dev_storage + 851;
 
 }
                 }
@@ -2933,7 +2952,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym117", 8) == 0)
                 {
 {
-return dev_storage + 837;
+return dev_storage + 841;
 
 }
                 }
@@ -2948,7 +2967,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym107", 8) == 0)
                 {
 {
-return dev_storage + 827;
+return dev_storage + 831;
 
 }
                 }
@@ -2972,7 +2991,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st6", 8) == 0)
                 {
 {
-return dev_storage + 464;
+return dev_storage + 465;
 
 }
                 }
@@ -2987,7 +3006,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr6", 8) == 0)
                 {
 {
-return dev_storage + 448;
+return dev_storage + 449;
 
 }
                 }
@@ -3002,7 +3021,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd6", 8) == 0)
                 {
 {
-return dev_storage + 156;
+return dev_storage + 157;
 
 }
                 }
@@ -3017,7 +3036,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym126", 8) == 0)
                 {
 {
-return dev_storage + 846;
+return dev_storage + 850;
 
 }
                 }
@@ -3032,7 +3051,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym116", 8) == 0)
                 {
 {
-return dev_storage + 836;
+return dev_storage + 840;
 
 }
                 }
@@ -3047,7 +3066,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym106", 8) == 0)
                 {
 {
-return dev_storage + 826;
+return dev_storage + 830;
 
 }
                 }
@@ -3071,7 +3090,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st5", 8) == 0)
                 {
 {
-return dev_storage + 463;
+return dev_storage + 464;
 
 }
                 }
@@ -3086,7 +3105,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr5", 8) == 0)
                 {
 {
-return dev_storage + 447;
+return dev_storage + 448;
 
 }
                 }
@@ -3101,7 +3120,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd5", 8) == 0)
                 {
 {
-return dev_storage + 155;
+return dev_storage + 156;
 
 }
                 }
@@ -3116,7 +3135,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym125", 8) == 0)
                 {
 {
-return dev_storage + 845;
+return dev_storage + 849;
 
 }
                 }
@@ -3131,7 +3150,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym115", 8) == 0)
                 {
 {
-return dev_storage + 835;
+return dev_storage + 839;
 
 }
                 }
@@ -3146,7 +3165,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym105", 8) == 0)
                 {
 {
-return dev_storage + 825;
+return dev_storage + 829;
 
 }
                 }
@@ -3170,7 +3189,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st4", 8) == 0)
                 {
 {
-return dev_storage + 462;
+return dev_storage + 463;
 
 }
                 }
@@ -3185,7 +3204,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr4", 8) == 0)
                 {
 {
-return dev_storage + 446;
+return dev_storage + 447;
 
 }
                 }
@@ -3200,7 +3219,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd4", 8) == 0)
                 {
 {
-return dev_storage + 154;
+return dev_storage + 155;
 
 }
                 }
@@ -3215,7 +3234,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym124", 8) == 0)
                 {
 {
-return dev_storage + 844;
+return dev_storage + 848;
 
 }
                 }
@@ -3230,7 +3249,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym114", 8) == 0)
                 {
 {
-return dev_storage + 834;
+return dev_storage + 838;
 
 }
                 }
@@ -3245,7 +3264,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym104", 8) == 0)
                 {
 {
-return dev_storage + 824;
+return dev_storage + 828;
 
 }
                 }
@@ -3269,7 +3288,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st3", 8) == 0)
                 {
 {
-return dev_storage + 461;
+return dev_storage + 462;
 
 }
                 }
@@ -3284,7 +3303,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr3", 8) == 0)
                 {
 {
-return dev_storage + 445;
+return dev_storage + 446;
 
 }
                 }
@@ -3299,7 +3318,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd3", 8) == 0)
                 {
 {
-return dev_storage + 153;
+return dev_storage + 154;
 
 }
                 }
@@ -3314,7 +3333,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym123", 8) == 0)
                 {
 {
-return dev_storage + 843;
+return dev_storage + 847;
 
 }
                 }
@@ -3329,7 +3348,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym113", 8) == 0)
                 {
 {
-return dev_storage + 833;
+return dev_storage + 837;
 
 }
                 }
@@ -3344,7 +3363,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym103", 8) == 0)
                 {
 {
-return dev_storage + 823;
+return dev_storage + 827;
 
 }
                 }
@@ -3368,7 +3387,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st2", 8) == 0)
                 {
 {
-return dev_storage + 460;
+return dev_storage + 461;
 
 }
                 }
@@ -3383,7 +3402,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr2", 8) == 0)
                 {
 {
-return dev_storage + 444;
+return dev_storage + 445;
 
 }
                 }
@@ -3398,7 +3417,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd2", 8) == 0)
                 {
 {
-return dev_storage + 152;
+return dev_storage + 153;
 
 }
                 }
@@ -3413,7 +3432,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym122", 8) == 0)
                 {
 {
-return dev_storage + 842;
+return dev_storage + 846;
 
 }
                 }
@@ -3428,7 +3447,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym112", 8) == 0)
                 {
 {
-return dev_storage + 832;
+return dev_storage + 836;
 
 }
                 }
@@ -3443,7 +3462,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym102", 8) == 0)
                 {
 {
-return dev_storage + 822;
+return dev_storage + 826;
 
 }
                 }
@@ -3467,7 +3486,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st1", 8) == 0)
                 {
 {
-return dev_storage + 459;
+return dev_storage + 460;
 
 }
                 }
@@ -3482,7 +3501,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr1", 8) == 0)
                 {
 {
-return dev_storage + 443;
+return dev_storage + 444;
 
 }
                 }
@@ -3497,7 +3516,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd1", 8) == 0)
                 {
 {
-return dev_storage + 151;
+return dev_storage + 152;
 
 }
                 }
@@ -3512,7 +3531,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym121", 8) == 0)
                 {
 {
-return dev_storage + 841;
+return dev_storage + 845;
 
 }
                 }
@@ -3527,7 +3546,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym111", 8) == 0)
                 {
 {
-return dev_storage + 831;
+return dev_storage + 835;
 
 }
                 }
@@ -3542,7 +3561,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym101", 8) == 0)
                 {
 {
-return dev_storage + 821;
+return dev_storage + 825;
 
 }
                 }
@@ -3566,7 +3585,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st0", 8) == 0)
                 {
 {
-return dev_storage + 458;
+return dev_storage + 459;
 
 }
                 }
@@ -3581,7 +3600,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/sr0", 8) == 0)
                 {
 {
-return dev_storage + 442;
+return dev_storage + 443;
 
 }
                 }
@@ -3596,7 +3615,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/fd0", 8) == 0)
                 {
 {
-return dev_storage + 150;
+return dev_storage + 151;
 
 }
                 }
@@ -3611,7 +3630,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym120", 8) == 0)
                 {
 {
-return dev_storage + 840;
+return dev_storage + 844;
 
 }
                 }
@@ -3626,7 +3645,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym110", 8) == 0)
                 {
 {
-return dev_storage + 830;
+return dev_storage + 834;
 
 }
                 }
@@ -3641,7 +3660,7 @@ return	NULL;
               if (strncmp (KR_keyword, ":ptym100", 8) == 0)
                 {
 {
-return dev_storage + 820;
+return dev_storage + 824;
 
 }
                 }
@@ -3671,7 +3690,7 @@ return	NULL;
           if (strncmp (KR_keyword, "/dev/ptmx", 9) == 0)
             {
 {
-return dev_storage + 296;
+return dev_storage + 297;
 
 }
             }
@@ -3686,7 +3705,7 @@ return	NULL;
           if (strncmp (KR_keyword, "/dev/zero", 9) == 0)
             {
 {
-return dev_storage + 717;
+return dev_storage + 721;
 
 }
             }
@@ -3704,7 +3723,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/null", 9) == 0)
                 {
 {
-return dev_storage + 295;
+return dev_storage + 296;
 
 }
                 }
@@ -3719,7 +3738,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/full", 9) == 0)
                 {
 {
-return dev_storage + 166;
+return dev_storage + 167;
 
 }
                 }
@@ -3743,7 +3762,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty9", 9) == 0)
                 {
 {
-return dev_storage + 306;
+return dev_storage + 307;
 
 }
                 }
@@ -3758,7 +3777,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst9", 9) == 0)
                 {
 {
-return dev_storage + 176;
+return dev_storage + 177;
 
 }
                 }
@@ -3788,7 +3807,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd9", 9) == 0)
                 {
 {
-return dev_storage + 435;
+return dev_storage + 436;
 
 }
                 }
@@ -3803,7 +3822,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st99", 9) == 0)
                 {
 {
-return dev_storage + 557;
+return dev_storage + 558;
 
 }
                 }
@@ -3818,7 +3837,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st89", 9) == 0)
                 {
 {
-return dev_storage + 547;
+return dev_storage + 548;
 
 }
                 }
@@ -3833,7 +3852,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st79", 9) == 0)
                 {
 {
-return dev_storage + 537;
+return dev_storage + 538;
 
 }
                 }
@@ -3848,7 +3867,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st69", 9) == 0)
                 {
 {
-return dev_storage + 527;
+return dev_storage + 528;
 
 }
                 }
@@ -3863,7 +3882,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st59", 9) == 0)
                 {
 {
-return dev_storage + 517;
+return dev_storage + 518;
 
 }
                 }
@@ -3878,7 +3897,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st49", 9) == 0)
                 {
 {
-return dev_storage + 507;
+return dev_storage + 508;
 
 }
                 }
@@ -3893,7 +3912,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st39", 9) == 0)
                 {
 {
-return dev_storage + 497;
+return dev_storage + 498;
 
 }
                 }
@@ -3908,7 +3927,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st29", 9) == 0)
                 {
 {
-return dev_storage + 487;
+return dev_storage + 488;
 
 }
                 }
@@ -3923,7 +3942,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st19", 9) == 0)
                 {
 {
-return dev_storage + 477;
+return dev_storage + 478;
 
 }
                 }
@@ -3947,7 +3966,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty8", 9) == 0)
                 {
 {
-return dev_storage + 305;
+return dev_storage + 306;
 
 }
                 }
@@ -3962,7 +3981,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst8", 9) == 0)
                 {
 {
-return dev_storage + 175;
+return dev_storage + 176;
 
 }
                 }
@@ -3992,7 +4011,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd8", 9) == 0)
                 {
 {
-return dev_storage + 434;
+return dev_storage + 435;
 
 }
                 }
@@ -4007,7 +4026,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st98", 9) == 0)
                 {
 {
-return dev_storage + 556;
+return dev_storage + 557;
 
 }
                 }
@@ -4022,7 +4041,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st88", 9) == 0)
                 {
 {
-return dev_storage + 546;
+return dev_storage + 547;
 
 }
                 }
@@ -4037,7 +4056,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st78", 9) == 0)
                 {
 {
-return dev_storage + 536;
+return dev_storage + 537;
 
 }
                 }
@@ -4052,7 +4071,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st68", 9) == 0)
                 {
 {
-return dev_storage + 526;
+return dev_storage + 527;
 
 }
                 }
@@ -4067,7 +4086,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st58", 9) == 0)
                 {
 {
-return dev_storage + 516;
+return dev_storage + 517;
 
 }
                 }
@@ -4082,7 +4101,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st48", 9) == 0)
                 {
 {
-return dev_storage + 506;
+return dev_storage + 507;
 
 }
                 }
@@ -4097,7 +4116,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st38", 9) == 0)
                 {
 {
-return dev_storage + 496;
+return dev_storage + 497;
 
 }
                 }
@@ -4112,7 +4131,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st28", 9) == 0)
                 {
 {
-return dev_storage + 486;
+return dev_storage + 487;
 
 }
                 }
@@ -4127,7 +4146,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st18", 9) == 0)
                 {
 {
-return dev_storage + 476;
+return dev_storage + 477;
 
 }
                 }
@@ -4151,7 +4170,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty7", 9) == 0)
                 {
 {
-return dev_storage + 304;
+return dev_storage + 305;
 
 }
                 }
@@ -4166,7 +4185,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst7", 9) == 0)
                 {
 {
-return dev_storage + 174;
+return dev_storage + 175;
 
 }
                 }
@@ -4196,7 +4215,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd7", 9) == 0)
                 {
 {
-return dev_storage + 433;
+return dev_storage + 434;
 
 }
                 }
@@ -4211,7 +4230,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st97", 9) == 0)
                 {
 {
-return dev_storage + 555;
+return dev_storage + 556;
 
 }
                 }
@@ -4226,7 +4245,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st87", 9) == 0)
                 {
 {
-return dev_storage + 545;
+return dev_storage + 546;
 
 }
                 }
@@ -4241,7 +4260,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st77", 9) == 0)
                 {
 {
-return dev_storage + 535;
+return dev_storage + 536;
 
 }
                 }
@@ -4256,7 +4275,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st67", 9) == 0)
                 {
 {
-return dev_storage + 525;
+return dev_storage + 526;
 
 }
                 }
@@ -4271,7 +4290,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st57", 9) == 0)
                 {
 {
-return dev_storage + 515;
+return dev_storage + 516;
 
 }
                 }
@@ -4286,7 +4305,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st47", 9) == 0)
                 {
 {
-return dev_storage + 505;
+return dev_storage + 506;
 
 }
                 }
@@ -4301,7 +4320,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st37", 9) == 0)
                 {
 {
-return dev_storage + 495;
+return dev_storage + 496;
 
 }
                 }
@@ -4316,7 +4335,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st27", 9) == 0)
                 {
 {
-return dev_storage + 485;
+return dev_storage + 486;
 
 }
                 }
@@ -4331,7 +4350,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st17", 9) == 0)
                 {
 {
-return dev_storage + 475;
+return dev_storage + 476;
 
 }
                 }
@@ -4355,7 +4374,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty6", 9) == 0)
                 {
 {
-return dev_storage + 303;
+return dev_storage + 304;
 
 }
                 }
@@ -4370,7 +4389,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst6", 9) == 0)
                 {
 {
-return dev_storage + 173;
+return dev_storage + 174;
 
 }
                 }
@@ -4400,7 +4419,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd6", 9) == 0)
                 {
 {
-return dev_storage + 432;
+return dev_storage + 433;
 
 }
                 }
@@ -4415,7 +4434,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st96", 9) == 0)
                 {
 {
-return dev_storage + 554;
+return dev_storage + 555;
 
 }
                 }
@@ -4430,7 +4449,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st86", 9) == 0)
                 {
 {
-return dev_storage + 544;
+return dev_storage + 545;
 
 }
                 }
@@ -4445,7 +4464,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st76", 9) == 0)
                 {
 {
-return dev_storage + 534;
+return dev_storage + 535;
 
 }
                 }
@@ -4460,7 +4479,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st66", 9) == 0)
                 {
 {
-return dev_storage + 524;
+return dev_storage + 525;
 
 }
                 }
@@ -4475,7 +4494,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st56", 9) == 0)
                 {
 {
-return dev_storage + 514;
+return dev_storage + 515;
 
 }
                 }
@@ -4490,7 +4509,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st46", 9) == 0)
                 {
 {
-return dev_storage + 504;
+return dev_storage + 505;
 
 }
                 }
@@ -4505,7 +4524,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st36", 9) == 0)
                 {
 {
-return dev_storage + 494;
+return dev_storage + 495;
 
 }
                 }
@@ -4520,7 +4539,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st26", 9) == 0)
                 {
 {
-return dev_storage + 484;
+return dev_storage + 485;
 
 }
                 }
@@ -4535,7 +4554,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st16", 9) == 0)
                 {
 {
-return dev_storage + 474;
+return dev_storage + 475;
 
 }
                 }
@@ -4559,7 +4578,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty5", 9) == 0)
                 {
 {
-return dev_storage + 302;
+return dev_storage + 303;
 
 }
                 }
@@ -4574,7 +4593,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst5", 9) == 0)
                 {
 {
-return dev_storage + 172;
+return dev_storage + 173;
 
 }
                 }
@@ -4604,7 +4623,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd5", 9) == 0)
                 {
 {
-return dev_storage + 431;
+return dev_storage + 432;
 
 }
                 }
@@ -4619,7 +4638,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st95", 9) == 0)
                 {
 {
-return dev_storage + 553;
+return dev_storage + 554;
 
 }
                 }
@@ -4634,7 +4653,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st85", 9) == 0)
                 {
 {
-return dev_storage + 543;
+return dev_storage + 544;
 
 }
                 }
@@ -4649,7 +4668,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st75", 9) == 0)
                 {
 {
-return dev_storage + 533;
+return dev_storage + 534;
 
 }
                 }
@@ -4664,7 +4683,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st65", 9) == 0)
                 {
 {
-return dev_storage + 523;
+return dev_storage + 524;
 
 }
                 }
@@ -4679,7 +4698,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st55", 9) == 0)
                 {
 {
-return dev_storage + 513;
+return dev_storage + 514;
 
 }
                 }
@@ -4694,7 +4713,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st45", 9) == 0)
                 {
 {
-return dev_storage + 503;
+return dev_storage + 504;
 
 }
                 }
@@ -4709,7 +4728,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st35", 9) == 0)
                 {
 {
-return dev_storage + 493;
+return dev_storage + 494;
 
 }
                 }
@@ -4724,7 +4743,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st25", 9) == 0)
                 {
 {
-return dev_storage + 483;
+return dev_storage + 484;
 
 }
                 }
@@ -4742,7 +4761,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st15", 9) == 0)
                     {
 {
-return dev_storage + 473;
+return dev_storage + 474;
 
 }
                     }
@@ -4757,7 +4776,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/sr15", 9) == 0)
                     {
 {
-return dev_storage + 457;
+return dev_storage + 458;
 
 }
                     }
@@ -4772,7 +4791,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/fd15", 9) == 0)
                     {
 {
-return dev_storage + 165;
+return dev_storage + 166;
 
 }
                     }
@@ -4802,7 +4821,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty4", 9) == 0)
                 {
 {
-return dev_storage + 301;
+return dev_storage + 302;
 
 }
                 }
@@ -4817,7 +4836,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst4", 9) == 0)
                 {
 {
-return dev_storage + 171;
+return dev_storage + 172;
 
 }
                 }
@@ -4847,7 +4866,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd4", 9) == 0)
                 {
 {
-return dev_storage + 430;
+return dev_storage + 431;
 
 }
                 }
@@ -4862,7 +4881,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st94", 9) == 0)
                 {
 {
-return dev_storage + 552;
+return dev_storage + 553;
 
 }
                 }
@@ -4877,7 +4896,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st84", 9) == 0)
                 {
 {
-return dev_storage + 542;
+return dev_storage + 543;
 
 }
                 }
@@ -4892,7 +4911,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st74", 9) == 0)
                 {
 {
-return dev_storage + 532;
+return dev_storage + 533;
 
 }
                 }
@@ -4907,7 +4926,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st64", 9) == 0)
                 {
 {
-return dev_storage + 522;
+return dev_storage + 523;
 
 }
                 }
@@ -4922,7 +4941,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st54", 9) == 0)
                 {
 {
-return dev_storage + 512;
+return dev_storage + 513;
 
 }
                 }
@@ -4937,7 +4956,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st44", 9) == 0)
                 {
 {
-return dev_storage + 502;
+return dev_storage + 503;
 
 }
                 }
@@ -4952,7 +4971,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st34", 9) == 0)
                 {
 {
-return dev_storage + 492;
+return dev_storage + 493;
 
 }
                 }
@@ -4967,7 +4986,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st24", 9) == 0)
                 {
 {
-return dev_storage + 482;
+return dev_storage + 483;
 
 }
                 }
@@ -4985,7 +5004,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st14", 9) == 0)
                     {
 {
-return dev_storage + 472;
+return dev_storage + 473;
 
 }
                     }
@@ -5000,7 +5019,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/sr14", 9) == 0)
                     {
 {
-return dev_storage + 456;
+return dev_storage + 457;
 
 }
                     }
@@ -5015,7 +5034,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/fd14", 9) == 0)
                     {
 {
-return dev_storage + 164;
+return dev_storage + 165;
 
 }
                     }
@@ -5045,7 +5064,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty3", 9) == 0)
                 {
 {
-return dev_storage + 300;
+return dev_storage + 301;
 
 }
                 }
@@ -5060,7 +5079,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst3", 9) == 0)
                 {
 {
-return dev_storage + 170;
+return dev_storage + 171;
 
 }
                 }
@@ -5090,7 +5109,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd3", 9) == 0)
                 {
 {
-return dev_storage + 429;
+return dev_storage + 430;
 
 }
                 }
@@ -5105,7 +5124,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st93", 9) == 0)
                 {
 {
-return dev_storage + 551;
+return dev_storage + 552;
 
 }
                 }
@@ -5120,7 +5139,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st83", 9) == 0)
                 {
 {
-return dev_storage + 541;
+return dev_storage + 542;
 
 }
                 }
@@ -5135,7 +5154,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st73", 9) == 0)
                 {
 {
-return dev_storage + 531;
+return dev_storage + 532;
 
 }
                 }
@@ -5150,7 +5169,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st63", 9) == 0)
                 {
 {
-return dev_storage + 521;
+return dev_storage + 522;
 
 }
                 }
@@ -5165,7 +5184,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st53", 9) == 0)
                 {
 {
-return dev_storage + 511;
+return dev_storage + 512;
 
 }
                 }
@@ -5180,7 +5199,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st43", 9) == 0)
                 {
 {
-return dev_storage + 501;
+return dev_storage + 502;
 
 }
                 }
@@ -5195,7 +5214,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st33", 9) == 0)
                 {
 {
-return dev_storage + 491;
+return dev_storage + 492;
 
 }
                 }
@@ -5210,7 +5229,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st23", 9) == 0)
                 {
 {
-return dev_storage + 481;
+return dev_storage + 482;
 
 }
                 }
@@ -5228,7 +5247,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st13", 9) == 0)
                     {
 {
-return dev_storage + 471;
+return dev_storage + 472;
 
 }
                     }
@@ -5243,7 +5262,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/sr13", 9) == 0)
                     {
 {
-return dev_storage + 455;
+return dev_storage + 456;
 
 }
                     }
@@ -5258,7 +5277,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/fd13", 9) == 0)
                     {
 {
-return dev_storage + 163;
+return dev_storage + 164;
 
 }
                     }
@@ -5288,7 +5307,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty2", 9) == 0)
                 {
 {
-return dev_storage + 299;
+return dev_storage + 300;
 
 }
                 }
@@ -5303,7 +5322,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst2", 9) == 0)
                 {
 {
-return dev_storage + 169;
+return dev_storage + 170;
 
 }
                 }
@@ -5333,7 +5352,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd2", 9) == 0)
                 {
 {
-return dev_storage + 428;
+return dev_storage + 429;
 
 }
                 }
@@ -5348,7 +5367,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st92", 9) == 0)
                 {
 {
-return dev_storage + 550;
+return dev_storage + 551;
 
 }
                 }
@@ -5363,7 +5382,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st82", 9) == 0)
                 {
 {
-return dev_storage + 540;
+return dev_storage + 541;
 
 }
                 }
@@ -5378,7 +5397,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st72", 9) == 0)
                 {
 {
-return dev_storage + 530;
+return dev_storage + 531;
 
 }
                 }
@@ -5393,7 +5412,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st62", 9) == 0)
                 {
 {
-return dev_storage + 520;
+return dev_storage + 521;
 
 }
                 }
@@ -5408,7 +5427,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st52", 9) == 0)
                 {
 {
-return dev_storage + 510;
+return dev_storage + 511;
 
 }
                 }
@@ -5423,7 +5442,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st42", 9) == 0)
                 {
 {
-return dev_storage + 500;
+return dev_storage + 501;
 
 }
                 }
@@ -5438,7 +5457,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st32", 9) == 0)
                 {
 {
-return dev_storage + 490;
+return dev_storage + 491;
 
 }
                 }
@@ -5453,7 +5472,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st22", 9) == 0)
                 {
 {
-return dev_storage + 480;
+return dev_storage + 481;
 
 }
                 }
@@ -5471,7 +5490,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st12", 9) == 0)
                     {
 {
-return dev_storage + 470;
+return dev_storage + 471;
 
 }
                     }
@@ -5486,7 +5505,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/sr12", 9) == 0)
                     {
 {
-return dev_storage + 454;
+return dev_storage + 455;
 
 }
                     }
@@ -5501,7 +5520,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/fd12", 9) == 0)
                     {
 {
-return dev_storage + 162;
+return dev_storage + 163;
 
 }
                     }
@@ -5531,7 +5550,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty1", 9) == 0)
                 {
 {
-return dev_storage + 298;
+return dev_storage + 299;
 
 }
                 }
@@ -5546,7 +5565,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst1", 9) == 0)
                 {
 {
-return dev_storage + 168;
+return dev_storage + 169;
 
 }
                 }
@@ -5576,7 +5595,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd1", 9) == 0)
                 {
 {
-return dev_storage + 427;
+return dev_storage + 428;
 
 }
                 }
@@ -5591,7 +5610,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st91", 9) == 0)
                 {
 {
-return dev_storage + 549;
+return dev_storage + 550;
 
 }
                 }
@@ -5606,7 +5625,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st81", 9) == 0)
                 {
 {
-return dev_storage + 539;
+return dev_storage + 540;
 
 }
                 }
@@ -5621,7 +5640,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st71", 9) == 0)
                 {
 {
-return dev_storage + 529;
+return dev_storage + 530;
 
 }
                 }
@@ -5636,7 +5655,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st61", 9) == 0)
                 {
 {
-return dev_storage + 519;
+return dev_storage + 520;
 
 }
                 }
@@ -5651,7 +5670,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st51", 9) == 0)
                 {
 {
-return dev_storage + 509;
+return dev_storage + 510;
 
 }
                 }
@@ -5666,7 +5685,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st41", 9) == 0)
                 {
 {
-return dev_storage + 499;
+return dev_storage + 500;
 
 }
                 }
@@ -5681,7 +5700,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st31", 9) == 0)
                 {
 {
-return dev_storage + 489;
+return dev_storage + 490;
 
 }
                 }
@@ -5696,7 +5715,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st21", 9) == 0)
                 {
 {
-return dev_storage + 479;
+return dev_storage + 480;
 
 }
                 }
@@ -5714,7 +5733,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st11", 9) == 0)
                     {
 {
-return dev_storage + 469;
+return dev_storage + 470;
 
 }
                     }
@@ -5729,7 +5748,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/sr11", 9) == 0)
                     {
 {
-return dev_storage + 453;
+return dev_storage + 454;
 
 }
                     }
@@ -5744,7 +5763,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/fd11", 9) == 0)
                     {
 {
-return dev_storage + 161;
+return dev_storage + 162;
 
 }
                     }
@@ -5774,7 +5793,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/pty0", 9) == 0)
                 {
 {
-return dev_storage + 297;
+return dev_storage + 298;
 
 }
                 }
@@ -5789,7 +5808,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/nst0", 9) == 0)
                 {
 {
-return dev_storage + 167;
+return dev_storage + 168;
 
 }
                 }
@@ -5804,7 +5823,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/scd0", 9) == 0)
                 {
 {
-return dev_storage + 426;
+return dev_storage + 427;
 
 }
                 }
@@ -5819,7 +5838,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st90", 9) == 0)
                 {
 {
-return dev_storage + 548;
+return dev_storage + 549;
 
 }
                 }
@@ -5834,7 +5853,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st80", 9) == 0)
                 {
 {
-return dev_storage + 538;
+return dev_storage + 539;
 
 }
                 }
@@ -5849,7 +5868,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st70", 9) == 0)
                 {
 {
-return dev_storage + 528;
+return dev_storage + 529;
 
 }
                 }
@@ -5864,7 +5883,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st60", 9) == 0)
                 {
 {
-return dev_storage + 518;
+return dev_storage + 519;
 
 }
                 }
@@ -5879,7 +5898,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st50", 9) == 0)
                 {
 {
-return dev_storage + 508;
+return dev_storage + 509;
 
 }
                 }
@@ -5894,7 +5913,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st40", 9) == 0)
                 {
 {
-return dev_storage + 498;
+return dev_storage + 499;
 
 }
                 }
@@ -5909,7 +5928,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st30", 9) == 0)
                 {
 {
-return dev_storage + 488;
+return dev_storage + 489;
 
 }
                 }
@@ -5924,7 +5943,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st20", 9) == 0)
                 {
 {
-return dev_storage + 478;
+return dev_storage + 479;
 
 }
                 }
@@ -5942,7 +5961,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st10", 9) == 0)
                     {
 {
-return dev_storage + 468;
+return dev_storage + 469;
 
 }
                     }
@@ -5957,7 +5976,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/sr10", 9) == 0)
                     {
 {
-return dev_storage + 452;
+return dev_storage + 453;
 
 }
                     }
@@ -5972,7 +5991,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/fd10", 9) == 0)
                     {
 {
-return dev_storage + 160;
+return dev_storage + 161;
 
 }
                     }
@@ -6164,15 +6183,39 @@ return	NULL;
 }
             }
         case 'i':
-          if (strncmp (KR_keyword, "/dev/conin", 10) == 0)
+          switch (KR_keyword [5])
             {
+            case 's':
+              if (strncmp (KR_keyword, "/dev/stdin", 10) == 0)
+                {
+{
+return dev_storage + 588;
+
+}
+                }
+              else
+                {
+{
+return	NULL;
+
+}
+                }
+            case 'c':
+              if (strncmp (KR_keyword, "/dev/conin", 10) == 0)
+                {
 {
 return dev_storage + 18;
 
 }
-            }
-          else
-            {
+                }
+              else
+                {
+{
+return	NULL;
+
+}
+                }
+            default:
 {
 return	NULL;
 
@@ -6185,7 +6228,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS9", 10) == 0)
                 {
 {
-return dev_storage + 596;
+return dev_storage + 600;
 
 }
                 }
@@ -6200,7 +6243,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS8", 10) == 0)
                 {
 {
-return dev_storage + 595;
+return dev_storage + 599;
 
 }
                 }
@@ -6215,7 +6258,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS7", 10) == 0)
                 {
 {
-return dev_storage + 594;
+return dev_storage + 598;
 
 }
                 }
@@ -6230,7 +6273,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS6", 10) == 0)
                 {
 {
-return dev_storage + 593;
+return dev_storage + 597;
 
 }
                 }
@@ -6245,7 +6288,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS5", 10) == 0)
                 {
 {
-return dev_storage + 592;
+return dev_storage + 596;
 
 }
                 }
@@ -6260,7 +6303,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS4", 10) == 0)
                 {
 {
-return dev_storage + 591;
+return dev_storage + 595;
 
 }
                 }
@@ -6275,7 +6318,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS3", 10) == 0)
                 {
 {
-return dev_storage + 590;
+return dev_storage + 594;
 
 }
                 }
@@ -6290,7 +6333,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS2", 10) == 0)
                 {
 {
-return dev_storage + 589;
+return dev_storage + 593;
 
 }
                 }
@@ -6305,7 +6348,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS1", 10) == 0)
                 {
 {
-return dev_storage + 588;
+return dev_storage + 592;
 
 }
                 }
@@ -6320,7 +6363,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/ttyS0", 10) == 0)
                 {
 {
-return dev_storage + 587;
+return dev_storage + 591;
 
 }
                 }
@@ -6347,7 +6390,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty99", 10) == 0)
                     {
 {
-return dev_storage + 396;
+return dev_storage + 397;
 
 }
                     }
@@ -6362,7 +6405,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty98", 10) == 0)
                     {
 {
-return dev_storage + 395;
+return dev_storage + 396;
 
 }
                     }
@@ -6377,7 +6420,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty97", 10) == 0)
                     {
 {
-return dev_storage + 394;
+return dev_storage + 395;
 
 }
                     }
@@ -6392,7 +6435,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty96", 10) == 0)
                     {
 {
-return dev_storage + 393;
+return dev_storage + 394;
 
 }
                     }
@@ -6407,7 +6450,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty95", 10) == 0)
                     {
 {
-return dev_storage + 392;
+return dev_storage + 393;
 
 }
                     }
@@ -6422,7 +6465,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty94", 10) == 0)
                     {
 {
-return dev_storage + 391;
+return dev_storage + 392;
 
 }
                     }
@@ -6437,7 +6480,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty93", 10) == 0)
                     {
 {
-return dev_storage + 390;
+return dev_storage + 391;
 
 }
                     }
@@ -6452,7 +6495,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty92", 10) == 0)
                     {
 {
-return dev_storage + 389;
+return dev_storage + 390;
 
 }
                     }
@@ -6467,7 +6510,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty91", 10) == 0)
                     {
 {
-return dev_storage + 388;
+return dev_storage + 389;
 
 }
                     }
@@ -6482,7 +6525,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty90", 10) == 0)
                     {
 {
-return dev_storage + 387;
+return dev_storage + 388;
 
 }
                     }
@@ -6506,7 +6549,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst99", 10) == 0)
                     {
 {
-return dev_storage + 266;
+return dev_storage + 267;
 
 }
                     }
@@ -6521,7 +6564,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst98", 10) == 0)
                     {
 {
-return dev_storage + 265;
+return dev_storage + 266;
 
 }
                     }
@@ -6536,7 +6579,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst97", 10) == 0)
                     {
 {
-return dev_storage + 264;
+return dev_storage + 265;
 
 }
                     }
@@ -6551,7 +6594,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst96", 10) == 0)
                     {
 {
-return dev_storage + 263;
+return dev_storage + 264;
 
 }
                     }
@@ -6566,7 +6609,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst95", 10) == 0)
                     {
 {
-return dev_storage + 262;
+return dev_storage + 263;
 
 }
                     }
@@ -6581,7 +6624,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst94", 10) == 0)
                     {
 {
-return dev_storage + 261;
+return dev_storage + 262;
 
 }
                     }
@@ -6596,7 +6639,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst93", 10) == 0)
                     {
 {
-return dev_storage + 260;
+return dev_storage + 261;
 
 }
                     }
@@ -6611,7 +6654,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst92", 10) == 0)
                     {
 {
-return dev_storage + 259;
+return dev_storage + 260;
 
 }
                     }
@@ -6626,7 +6669,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst91", 10) == 0)
                     {
 {
-return dev_storage + 258;
+return dev_storage + 259;
 
 }
                     }
@@ -6641,7 +6684,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst90", 10) == 0)
                     {
 {
-return dev_storage + 257;
+return dev_storage + 258;
 
 }
                     }
@@ -6674,7 +6717,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty89", 10) == 0)
                     {
 {
-return dev_storage + 386;
+return dev_storage + 387;
 
 }
                     }
@@ -6689,7 +6732,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty88", 10) == 0)
                     {
 {
-return dev_storage + 385;
+return dev_storage + 386;
 
 }
                     }
@@ -6704,7 +6747,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty87", 10) == 0)
                     {
 {
-return dev_storage + 384;
+return dev_storage + 385;
 
 }
                     }
@@ -6719,7 +6762,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty86", 10) == 0)
                     {
 {
-return dev_storage + 383;
+return dev_storage + 384;
 
 }
                     }
@@ -6734,7 +6777,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty85", 10) == 0)
                     {
 {
-return dev_storage + 382;
+return dev_storage + 383;
 
 }
                     }
@@ -6749,7 +6792,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty84", 10) == 0)
                     {
 {
-return dev_storage + 381;
+return dev_storage + 382;
 
 }
                     }
@@ -6764,7 +6807,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty83", 10) == 0)
                     {
 {
-return dev_storage + 380;
+return dev_storage + 381;
 
 }
                     }
@@ -6779,7 +6822,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty82", 10) == 0)
                     {
 {
-return dev_storage + 379;
+return dev_storage + 380;
 
 }
                     }
@@ -6794,7 +6837,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty81", 10) == 0)
                     {
 {
-return dev_storage + 378;
+return dev_storage + 379;
 
 }
                     }
@@ -6809,7 +6852,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty80", 10) == 0)
                     {
 {
-return dev_storage + 377;
+return dev_storage + 378;
 
 }
                     }
@@ -6833,7 +6876,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst89", 10) == 0)
                     {
 {
-return dev_storage + 256;
+return dev_storage + 257;
 
 }
                     }
@@ -6848,7 +6891,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst88", 10) == 0)
                     {
 {
-return dev_storage + 255;
+return dev_storage + 256;
 
 }
                     }
@@ -6863,7 +6906,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst87", 10) == 0)
                     {
 {
-return dev_storage + 254;
+return dev_storage + 255;
 
 }
                     }
@@ -6878,7 +6921,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst86", 10) == 0)
                     {
 {
-return dev_storage + 253;
+return dev_storage + 254;
 
 }
                     }
@@ -6893,7 +6936,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst85", 10) == 0)
                     {
 {
-return dev_storage + 252;
+return dev_storage + 253;
 
 }
                     }
@@ -6908,7 +6951,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst84", 10) == 0)
                     {
 {
-return dev_storage + 251;
+return dev_storage + 252;
 
 }
                     }
@@ -6923,7 +6966,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst83", 10) == 0)
                     {
 {
-return dev_storage + 250;
+return dev_storage + 251;
 
 }
                     }
@@ -6938,7 +6981,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst82", 10) == 0)
                     {
 {
-return dev_storage + 249;
+return dev_storage + 250;
 
 }
                     }
@@ -6953,7 +6996,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst81", 10) == 0)
                     {
 {
-return dev_storage + 248;
+return dev_storage + 249;
 
 }
                     }
@@ -6968,7 +7011,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst80", 10) == 0)
                     {
 {
-return dev_storage + 247;
+return dev_storage + 248;
 
 }
                     }
@@ -7001,7 +7044,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty79", 10) == 0)
                     {
 {
-return dev_storage + 376;
+return dev_storage + 377;
 
 }
                     }
@@ -7016,7 +7059,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty78", 10) == 0)
                     {
 {
-return dev_storage + 375;
+return dev_storage + 376;
 
 }
                     }
@@ -7031,7 +7074,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty77", 10) == 0)
                     {
 {
-return dev_storage + 374;
+return dev_storage + 375;
 
 }
                     }
@@ -7046,7 +7089,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty76", 10) == 0)
                     {
 {
-return dev_storage + 373;
+return dev_storage + 374;
 
 }
                     }
@@ -7061,7 +7104,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty75", 10) == 0)
                     {
 {
-return dev_storage + 372;
+return dev_storage + 373;
 
 }
                     }
@@ -7076,7 +7119,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty74", 10) == 0)
                     {
 {
-return dev_storage + 371;
+return dev_storage + 372;
 
 }
                     }
@@ -7091,7 +7134,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty73", 10) == 0)
                     {
 {
-return dev_storage + 370;
+return dev_storage + 371;
 
 }
                     }
@@ -7106,7 +7149,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty72", 10) == 0)
                     {
 {
-return dev_storage + 369;
+return dev_storage + 370;
 
 }
                     }
@@ -7121,7 +7164,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty71", 10) == 0)
                     {
 {
-return dev_storage + 368;
+return dev_storage + 369;
 
 }
                     }
@@ -7136,7 +7179,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty70", 10) == 0)
                     {
 {
-return dev_storage + 367;
+return dev_storage + 368;
 
 }
                     }
@@ -7160,7 +7203,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst79", 10) == 0)
                     {
 {
-return dev_storage + 246;
+return dev_storage + 247;
 
 }
                     }
@@ -7175,7 +7218,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst78", 10) == 0)
                     {
 {
-return dev_storage + 245;
+return dev_storage + 246;
 
 }
                     }
@@ -7190,7 +7233,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst77", 10) == 0)
                     {
 {
-return dev_storage + 244;
+return dev_storage + 245;
 
 }
                     }
@@ -7205,7 +7248,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst76", 10) == 0)
                     {
 {
-return dev_storage + 243;
+return dev_storage + 244;
 
 }
                     }
@@ -7220,7 +7263,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst75", 10) == 0)
                     {
 {
-return dev_storage + 242;
+return dev_storage + 243;
 
 }
                     }
@@ -7235,7 +7278,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst74", 10) == 0)
                     {
 {
-return dev_storage + 241;
+return dev_storage + 242;
 
 }
                     }
@@ -7250,7 +7293,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst73", 10) == 0)
                     {
 {
-return dev_storage + 240;
+return dev_storage + 241;
 
 }
                     }
@@ -7265,7 +7308,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst72", 10) == 0)
                     {
 {
-return dev_storage + 239;
+return dev_storage + 240;
 
 }
                     }
@@ -7280,7 +7323,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst71", 10) == 0)
                     {
 {
-return dev_storage + 238;
+return dev_storage + 239;
 
 }
                     }
@@ -7295,7 +7338,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst70", 10) == 0)
                     {
 {
-return dev_storage + 237;
+return dev_storage + 238;
 
 }
                     }
@@ -7328,7 +7371,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty69", 10) == 0)
                     {
 {
-return dev_storage + 366;
+return dev_storage + 367;
 
 }
                     }
@@ -7343,7 +7386,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty68", 10) == 0)
                     {
 {
-return dev_storage + 365;
+return dev_storage + 366;
 
 }
                     }
@@ -7358,7 +7401,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty67", 10) == 0)
                     {
 {
-return dev_storage + 364;
+return dev_storage + 365;
 
 }
                     }
@@ -7373,7 +7416,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty66", 10) == 0)
                     {
 {
-return dev_storage + 363;
+return dev_storage + 364;
 
 }
                     }
@@ -7388,7 +7431,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty65", 10) == 0)
                     {
 {
-return dev_storage + 362;
+return dev_storage + 363;
 
 }
                     }
@@ -7403,7 +7446,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty64", 10) == 0)
                     {
 {
-return dev_storage + 361;
+return dev_storage + 362;
 
 }
                     }
@@ -7418,7 +7461,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty63", 10) == 0)
                     {
 {
-return dev_storage + 360;
+return dev_storage + 361;
 
 }
                     }
@@ -7433,7 +7476,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty62", 10) == 0)
                     {
 {
-return dev_storage + 359;
+return dev_storage + 360;
 
 }
                     }
@@ -7448,7 +7491,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty61", 10) == 0)
                     {
 {
-return dev_storage + 358;
+return dev_storage + 359;
 
 }
                     }
@@ -7463,7 +7506,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty60", 10) == 0)
                     {
 {
-return dev_storage + 357;
+return dev_storage + 358;
 
 }
                     }
@@ -7487,7 +7530,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst69", 10) == 0)
                     {
 {
-return dev_storage + 236;
+return dev_storage + 237;
 
 }
                     }
@@ -7502,7 +7545,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst68", 10) == 0)
                     {
 {
-return dev_storage + 235;
+return dev_storage + 236;
 
 }
                     }
@@ -7517,7 +7560,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst67", 10) == 0)
                     {
 {
-return dev_storage + 234;
+return dev_storage + 235;
 
 }
                     }
@@ -7532,7 +7575,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst66", 10) == 0)
                     {
 {
-return dev_storage + 233;
+return dev_storage + 234;
 
 }
                     }
@@ -7547,7 +7590,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst65", 10) == 0)
                     {
 {
-return dev_storage + 232;
+return dev_storage + 233;
 
 }
                     }
@@ -7562,7 +7605,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst64", 10) == 0)
                     {
 {
-return dev_storage + 231;
+return dev_storage + 232;
 
 }
                     }
@@ -7577,7 +7620,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst63", 10) == 0)
                     {
 {
-return dev_storage + 230;
+return dev_storage + 231;
 
 }
                     }
@@ -7592,7 +7635,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst62", 10) == 0)
                     {
 {
-return dev_storage + 229;
+return dev_storage + 230;
 
 }
                     }
@@ -7607,7 +7650,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst61", 10) == 0)
                     {
 {
-return dev_storage + 228;
+return dev_storage + 229;
 
 }
                     }
@@ -7622,7 +7665,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst60", 10) == 0)
                     {
 {
-return dev_storage + 227;
+return dev_storage + 228;
 
 }
                     }
@@ -7655,7 +7698,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty59", 10) == 0)
                     {
 {
-return dev_storage + 356;
+return dev_storage + 357;
 
 }
                     }
@@ -7670,7 +7713,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty58", 10) == 0)
                     {
 {
-return dev_storage + 355;
+return dev_storage + 356;
 
 }
                     }
@@ -7685,7 +7728,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty57", 10) == 0)
                     {
 {
-return dev_storage + 354;
+return dev_storage + 355;
 
 }
                     }
@@ -7700,7 +7743,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty56", 10) == 0)
                     {
 {
-return dev_storage + 353;
+return dev_storage + 354;
 
 }
                     }
@@ -7715,7 +7758,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty55", 10) == 0)
                     {
 {
-return dev_storage + 352;
+return dev_storage + 353;
 
 }
                     }
@@ -7730,7 +7773,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty54", 10) == 0)
                     {
 {
-return dev_storage + 351;
+return dev_storage + 352;
 
 }
                     }
@@ -7745,7 +7788,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty53", 10) == 0)
                     {
 {
-return dev_storage + 350;
+return dev_storage + 351;
 
 }
                     }
@@ -7760,7 +7803,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty52", 10) == 0)
                     {
 {
-return dev_storage + 349;
+return dev_storage + 350;
 
 }
                     }
@@ -7775,7 +7818,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty51", 10) == 0)
                     {
 {
-return dev_storage + 348;
+return dev_storage + 349;
 
 }
                     }
@@ -7790,7 +7833,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty50", 10) == 0)
                     {
 {
-return dev_storage + 347;
+return dev_storage + 348;
 
 }
                     }
@@ -7814,7 +7857,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst59", 10) == 0)
                     {
 {
-return dev_storage + 226;
+return dev_storage + 227;
 
 }
                     }
@@ -7829,7 +7872,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst58", 10) == 0)
                     {
 {
-return dev_storage + 225;
+return dev_storage + 226;
 
 }
                     }
@@ -7844,7 +7887,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst57", 10) == 0)
                     {
 {
-return dev_storage + 224;
+return dev_storage + 225;
 
 }
                     }
@@ -7859,7 +7902,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst56", 10) == 0)
                     {
 {
-return dev_storage + 223;
+return dev_storage + 224;
 
 }
                     }
@@ -7874,7 +7917,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst55", 10) == 0)
                     {
 {
-return dev_storage + 222;
+return dev_storage + 223;
 
 }
                     }
@@ -7889,7 +7932,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst54", 10) == 0)
                     {
 {
-return dev_storage + 221;
+return dev_storage + 222;
 
 }
                     }
@@ -7904,7 +7947,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst53", 10) == 0)
                     {
 {
-return dev_storage + 220;
+return dev_storage + 221;
 
 }
                     }
@@ -7919,7 +7962,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst52", 10) == 0)
                     {
 {
-return dev_storage + 219;
+return dev_storage + 220;
 
 }
                     }
@@ -7934,7 +7977,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst51", 10) == 0)
                     {
 {
-return dev_storage + 218;
+return dev_storage + 219;
 
 }
                     }
@@ -7949,7 +7992,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst50", 10) == 0)
                     {
 {
-return dev_storage + 217;
+return dev_storage + 218;
 
 }
                     }
@@ -7982,7 +8025,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty49", 10) == 0)
                     {
 {
-return dev_storage + 346;
+return dev_storage + 347;
 
 }
                     }
@@ -7997,7 +8040,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty48", 10) == 0)
                     {
 {
-return dev_storage + 345;
+return dev_storage + 346;
 
 }
                     }
@@ -8012,7 +8055,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty47", 10) == 0)
                     {
 {
-return dev_storage + 344;
+return dev_storage + 345;
 
 }
                     }
@@ -8027,7 +8070,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty46", 10) == 0)
                     {
 {
-return dev_storage + 343;
+return dev_storage + 344;
 
 }
                     }
@@ -8042,7 +8085,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty45", 10) == 0)
                     {
 {
-return dev_storage + 342;
+return dev_storage + 343;
 
 }
                     }
@@ -8057,7 +8100,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty44", 10) == 0)
                     {
 {
-return dev_storage + 341;
+return dev_storage + 342;
 
 }
                     }
@@ -8072,7 +8115,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty43", 10) == 0)
                     {
 {
-return dev_storage + 340;
+return dev_storage + 341;
 
 }
                     }
@@ -8087,7 +8130,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty42", 10) == 0)
                     {
 {
-return dev_storage + 339;
+return dev_storage + 340;
 
 }
                     }
@@ -8102,7 +8145,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty41", 10) == 0)
                     {
 {
-return dev_storage + 338;
+return dev_storage + 339;
 
 }
                     }
@@ -8117,7 +8160,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty40", 10) == 0)
                     {
 {
-return dev_storage + 337;
+return dev_storage + 338;
 
 }
                     }
@@ -8141,7 +8184,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst49", 10) == 0)
                     {
 {
-return dev_storage + 216;
+return dev_storage + 217;
 
 }
                     }
@@ -8156,7 +8199,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst48", 10) == 0)
                     {
 {
-return dev_storage + 215;
+return dev_storage + 216;
 
 }
                     }
@@ -8171,7 +8214,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst47", 10) == 0)
                     {
 {
-return dev_storage + 214;
+return dev_storage + 215;
 
 }
                     }
@@ -8186,7 +8229,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst46", 10) == 0)
                     {
 {
-return dev_storage + 213;
+return dev_storage + 214;
 
 }
                     }
@@ -8201,7 +8244,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst45", 10) == 0)
                     {
 {
-return dev_storage + 212;
+return dev_storage + 213;
 
 }
                     }
@@ -8216,7 +8259,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst44", 10) == 0)
                     {
 {
-return dev_storage + 211;
+return dev_storage + 212;
 
 }
                     }
@@ -8231,7 +8274,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst43", 10) == 0)
                     {
 {
-return dev_storage + 210;
+return dev_storage + 211;
 
 }
                     }
@@ -8246,7 +8289,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst42", 10) == 0)
                     {
 {
-return dev_storage + 209;
+return dev_storage + 210;
 
 }
                     }
@@ -8261,7 +8304,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst41", 10) == 0)
                     {
 {
-return dev_storage + 208;
+return dev_storage + 209;
 
 }
                     }
@@ -8276,7 +8319,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst40", 10) == 0)
                     {
 {
-return dev_storage + 207;
+return dev_storage + 208;
 
 }
                     }
@@ -8309,7 +8352,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty39", 10) == 0)
                     {
 {
-return dev_storage + 336;
+return dev_storage + 337;
 
 }
                     }
@@ -8324,7 +8367,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty38", 10) == 0)
                     {
 {
-return dev_storage + 335;
+return dev_storage + 336;
 
 }
                     }
@@ -8339,7 +8382,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty37", 10) == 0)
                     {
 {
-return dev_storage + 334;
+return dev_storage + 335;
 
 }
                     }
@@ -8354,7 +8397,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty36", 10) == 0)
                     {
 {
-return dev_storage + 333;
+return dev_storage + 334;
 
 }
                     }
@@ -8369,7 +8412,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty35", 10) == 0)
                     {
 {
-return dev_storage + 332;
+return dev_storage + 333;
 
 }
                     }
@@ -8384,7 +8427,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty34", 10) == 0)
                     {
 {
-return dev_storage + 331;
+return dev_storage + 332;
 
 }
                     }
@@ -8399,7 +8442,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty33", 10) == 0)
                     {
 {
-return dev_storage + 330;
+return dev_storage + 331;
 
 }
                     }
@@ -8414,7 +8457,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty32", 10) == 0)
                     {
 {
-return dev_storage + 329;
+return dev_storage + 330;
 
 }
                     }
@@ -8429,7 +8472,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty31", 10) == 0)
                     {
 {
-return dev_storage + 328;
+return dev_storage + 329;
 
 }
                     }
@@ -8444,7 +8487,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty30", 10) == 0)
                     {
 {
-return dev_storage + 327;
+return dev_storage + 328;
 
 }
                     }
@@ -8468,7 +8511,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst39", 10) == 0)
                     {
 {
-return dev_storage + 206;
+return dev_storage + 207;
 
 }
                     }
@@ -8483,7 +8526,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst38", 10) == 0)
                     {
 {
-return dev_storage + 205;
+return dev_storage + 206;
 
 }
                     }
@@ -8498,7 +8541,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst37", 10) == 0)
                     {
 {
-return dev_storage + 204;
+return dev_storage + 205;
 
 }
                     }
@@ -8513,7 +8556,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst36", 10) == 0)
                     {
 {
-return dev_storage + 203;
+return dev_storage + 204;
 
 }
                     }
@@ -8528,7 +8571,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst35", 10) == 0)
                     {
 {
-return dev_storage + 202;
+return dev_storage + 203;
 
 }
                     }
@@ -8543,7 +8586,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst34", 10) == 0)
                     {
 {
-return dev_storage + 201;
+return dev_storage + 202;
 
 }
                     }
@@ -8558,7 +8601,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst33", 10) == 0)
                     {
 {
-return dev_storage + 200;
+return dev_storage + 201;
 
 }
                     }
@@ -8573,7 +8616,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst32", 10) == 0)
                     {
 {
-return dev_storage + 199;
+return dev_storage + 200;
 
 }
                     }
@@ -8588,7 +8631,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst31", 10) == 0)
                     {
 {
-return dev_storage + 198;
+return dev_storage + 199;
 
 }
                     }
@@ -8603,7 +8646,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst30", 10) == 0)
                     {
 {
-return dev_storage + 197;
+return dev_storage + 198;
 
 }
                     }
@@ -8636,7 +8679,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st127", 10) == 0)
                     {
 {
-return dev_storage + 585;
+return dev_storage + 586;
 
 }
                     }
@@ -8651,7 +8694,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st126", 10) == 0)
                     {
 {
-return dev_storage + 584;
+return dev_storage + 585;
 
 }
                     }
@@ -8666,7 +8709,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st125", 10) == 0)
                     {
 {
-return dev_storage + 583;
+return dev_storage + 584;
 
 }
                     }
@@ -8681,7 +8724,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st124", 10) == 0)
                     {
 {
-return dev_storage + 582;
+return dev_storage + 583;
 
 }
                     }
@@ -8696,7 +8739,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st123", 10) == 0)
                     {
 {
-return dev_storage + 581;
+return dev_storage + 582;
 
 }
                     }
@@ -8711,7 +8754,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st122", 10) == 0)
                     {
 {
-return dev_storage + 580;
+return dev_storage + 581;
 
 }
                     }
@@ -8726,7 +8769,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st121", 10) == 0)
                     {
 {
-return dev_storage + 579;
+return dev_storage + 580;
 
 }
                     }
@@ -8741,7 +8784,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st120", 10) == 0)
                     {
 {
-return dev_storage + 578;
+return dev_storage + 579;
 
 }
                     }
@@ -8765,7 +8808,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty29", 10) == 0)
                     {
 {
-return dev_storage + 326;
+return dev_storage + 327;
 
 }
                     }
@@ -8780,7 +8823,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty28", 10) == 0)
                     {
 {
-return dev_storage + 325;
+return dev_storage + 326;
 
 }
                     }
@@ -8795,7 +8838,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty27", 10) == 0)
                     {
 {
-return dev_storage + 324;
+return dev_storage + 325;
 
 }
                     }
@@ -8810,7 +8853,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty26", 10) == 0)
                     {
 {
-return dev_storage + 323;
+return dev_storage + 324;
 
 }
                     }
@@ -8825,7 +8868,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty25", 10) == 0)
                     {
 {
-return dev_storage + 322;
+return dev_storage + 323;
 
 }
                     }
@@ -8840,7 +8883,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty24", 10) == 0)
                     {
 {
-return dev_storage + 321;
+return dev_storage + 322;
 
 }
                     }
@@ -8855,7 +8898,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty23", 10) == 0)
                     {
 {
-return dev_storage + 320;
+return dev_storage + 321;
 
 }
                     }
@@ -8870,7 +8913,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty22", 10) == 0)
                     {
 {
-return dev_storage + 319;
+return dev_storage + 320;
 
 }
                     }
@@ -8885,7 +8928,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty21", 10) == 0)
                     {
 {
-return dev_storage + 318;
+return dev_storage + 319;
 
 }
                     }
@@ -8900,7 +8943,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty20", 10) == 0)
                     {
 {
-return dev_storage + 317;
+return dev_storage + 318;
 
 }
                     }
@@ -8924,7 +8967,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst29", 10) == 0)
                     {
 {
-return dev_storage + 196;
+return dev_storage + 197;
 
 }
                     }
@@ -8939,7 +8982,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst28", 10) == 0)
                     {
 {
-return dev_storage + 195;
+return dev_storage + 196;
 
 }
                     }
@@ -8954,7 +8997,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst27", 10) == 0)
                     {
 {
-return dev_storage + 194;
+return dev_storage + 195;
 
 }
                     }
@@ -8969,7 +9012,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst26", 10) == 0)
                     {
 {
-return dev_storage + 193;
+return dev_storage + 194;
 
 }
                     }
@@ -8984,7 +9027,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst25", 10) == 0)
                     {
 {
-return dev_storage + 192;
+return dev_storage + 193;
 
 }
                     }
@@ -8999,7 +9042,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst24", 10) == 0)
                     {
 {
-return dev_storage + 191;
+return dev_storage + 192;
 
 }
                     }
@@ -9014,7 +9057,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst23", 10) == 0)
                     {
 {
-return dev_storage + 190;
+return dev_storage + 191;
 
 }
                     }
@@ -9029,7 +9072,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst22", 10) == 0)
                     {
 {
-return dev_storage + 189;
+return dev_storage + 190;
 
 }
                     }
@@ -9044,7 +9087,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst21", 10) == 0)
                     {
 {
-return dev_storage + 188;
+return dev_storage + 189;
 
 }
                     }
@@ -9059,7 +9102,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst20", 10) == 0)
                     {
 {
-return dev_storage + 187;
+return dev_storage + 188;
 
 }
                     }
@@ -9092,7 +9135,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty19", 10) == 0)
                     {
 {
-return dev_storage + 316;
+return dev_storage + 317;
 
 }
                     }
@@ -9107,7 +9150,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty18", 10) == 0)
                     {
 {
-return dev_storage + 315;
+return dev_storage + 316;
 
 }
                     }
@@ -9122,7 +9165,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty17", 10) == 0)
                     {
 {
-return dev_storage + 314;
+return dev_storage + 315;
 
 }
                     }
@@ -9137,7 +9180,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty16", 10) == 0)
                     {
 {
-return dev_storage + 313;
+return dev_storage + 314;
 
 }
                     }
@@ -9152,7 +9195,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty15", 10) == 0)
                     {
 {
-return dev_storage + 312;
+return dev_storage + 313;
 
 }
                     }
@@ -9167,7 +9210,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty14", 10) == 0)
                     {
 {
-return dev_storage + 311;
+return dev_storage + 312;
 
 }
                     }
@@ -9182,7 +9225,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty13", 10) == 0)
                     {
 {
-return dev_storage + 310;
+return dev_storage + 311;
 
 }
                     }
@@ -9197,7 +9240,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty12", 10) == 0)
                     {
 {
-return dev_storage + 309;
+return dev_storage + 310;
 
 }
                     }
@@ -9212,7 +9255,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty11", 10) == 0)
                     {
 {
-return dev_storage + 308;
+return dev_storage + 309;
 
 }
                     }
@@ -9227,7 +9270,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty10", 10) == 0)
                     {
 {
-return dev_storage + 307;
+return dev_storage + 308;
 
 }
                     }
@@ -9251,7 +9294,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst19", 10) == 0)
                     {
 {
-return dev_storage + 186;
+return dev_storage + 187;
 
 }
                     }
@@ -9266,7 +9309,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst18", 10) == 0)
                     {
 {
-return dev_storage + 185;
+return dev_storage + 186;
 
 }
                     }
@@ -9281,7 +9324,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst17", 10) == 0)
                     {
 {
-return dev_storage + 184;
+return dev_storage + 185;
 
 }
                     }
@@ -9296,7 +9339,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst16", 10) == 0)
                     {
 {
-return dev_storage + 183;
+return dev_storage + 184;
 
 }
                     }
@@ -9311,7 +9354,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst15", 10) == 0)
                     {
 {
-return dev_storage + 182;
+return dev_storage + 183;
 
 }
                     }
@@ -9326,7 +9369,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst14", 10) == 0)
                     {
 {
-return dev_storage + 181;
+return dev_storage + 182;
 
 }
                     }
@@ -9341,7 +9384,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst13", 10) == 0)
                     {
 {
-return dev_storage + 180;
+return dev_storage + 181;
 
 }
                     }
@@ -9356,7 +9399,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst12", 10) == 0)
                     {
 {
-return dev_storage + 179;
+return dev_storage + 180;
 
 }
                     }
@@ -9371,7 +9414,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst11", 10) == 0)
                     {
 {
-return dev_storage + 178;
+return dev_storage + 179;
 
 }
                     }
@@ -9386,7 +9429,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst10", 10) == 0)
                     {
 {
-return dev_storage + 177;
+return dev_storage + 178;
 
 }
                     }
@@ -9524,7 +9567,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/scd15", 10) == 0)
                     {
 {
-return dev_storage + 441;
+return dev_storage + 442;
 
 }
                     }
@@ -9539,7 +9582,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/scd14", 10) == 0)
                     {
 {
-return dev_storage + 440;
+return dev_storage + 441;
 
 }
                     }
@@ -9554,7 +9597,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/scd13", 10) == 0)
                     {
 {
-return dev_storage + 439;
+return dev_storage + 440;
 
 }
                     }
@@ -9569,7 +9612,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/scd12", 10) == 0)
                     {
 {
-return dev_storage + 438;
+return dev_storage + 439;
 
 }
                     }
@@ -9584,7 +9627,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/scd11", 10) == 0)
                     {
 {
-return dev_storage + 437;
+return dev_storage + 438;
 
 }
                     }
@@ -9599,7 +9642,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/scd10", 10) == 0)
                     {
 {
-return dev_storage + 436;
+return dev_storage + 437;
 
 }
                     }
@@ -9623,7 +9666,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st119", 10) == 0)
                     {
 {
-return dev_storage + 577;
+return dev_storage + 578;
 
 }
                     }
@@ -9638,7 +9681,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st118", 10) == 0)
                     {
 {
-return dev_storage + 576;
+return dev_storage + 577;
 
 }
                     }
@@ -9653,7 +9696,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st117", 10) == 0)
                     {
 {
-return dev_storage + 575;
+return dev_storage + 576;
 
 }
                     }
@@ -9668,7 +9711,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st116", 10) == 0)
                     {
 {
-return dev_storage + 574;
+return dev_storage + 575;
 
 }
                     }
@@ -9683,7 +9726,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st115", 10) == 0)
                     {
 {
-return dev_storage + 573;
+return dev_storage + 574;
 
 }
                     }
@@ -9698,7 +9741,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st114", 10) == 0)
                     {
 {
-return dev_storage + 572;
+return dev_storage + 573;
 
 }
                     }
@@ -9713,7 +9756,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st113", 10) == 0)
                     {
 {
-return dev_storage + 571;
+return dev_storage + 572;
 
 }
                     }
@@ -9728,7 +9771,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st112", 10) == 0)
                     {
 {
-return dev_storage + 570;
+return dev_storage + 571;
 
 }
                     }
@@ -9743,7 +9786,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st111", 10) == 0)
                     {
 {
-return dev_storage + 569;
+return dev_storage + 570;
 
 }
                     }
@@ -9758,7 +9801,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/st110", 10) == 0)
                     {
 {
-return dev_storage + 568;
+return dev_storage + 569;
 
 }
                     }
@@ -9788,7 +9831,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st109", 10) == 0)
                 {
 {
-return dev_storage + 567;
+return dev_storage + 568;
 
 }
                 }
@@ -9803,7 +9846,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st108", 10) == 0)
                 {
 {
-return dev_storage + 566;
+return dev_storage + 567;
 
 }
                 }
@@ -9818,7 +9861,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st107", 10) == 0)
                 {
 {
-return dev_storage + 565;
+return dev_storage + 566;
 
 }
                 }
@@ -9833,7 +9876,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st106", 10) == 0)
                 {
 {
-return dev_storage + 564;
+return dev_storage + 565;
 
 }
                 }
@@ -9848,7 +9891,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st105", 10) == 0)
                 {
 {
-return dev_storage + 563;
+return dev_storage + 564;
 
 }
                 }
@@ -9863,7 +9906,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st104", 10) == 0)
                 {
 {
-return dev_storage + 562;
+return dev_storage + 563;
 
 }
                 }
@@ -9878,7 +9921,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st103", 10) == 0)
                 {
 {
-return dev_storage + 561;
+return dev_storage + 562;
 
 }
                 }
@@ -9893,7 +9936,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st102", 10) == 0)
                 {
 {
-return dev_storage + 560;
+return dev_storage + 561;
 
 }
                 }
@@ -9908,7 +9951,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st101", 10) == 0)
                 {
 {
-return dev_storage + 559;
+return dev_storage + 560;
 
 }
                 }
@@ -9923,7 +9966,7 @@ return	NULL;
               if (strncmp (KR_keyword, "/dev/st100", 10) == 0)
                 {
 {
-return dev_storage + 558;
+return dev_storage + 559;
 
 }
                 }
@@ -9950,10 +9993,49 @@ return	NULL;
       switch (KR_keyword [9])
         {
         case 'u':
-          if (strncmp (KR_keyword, "/dev/conout", 11) == 0)
+          switch (KR_keyword [5])
             {
+            case 's':
+              if (strncmp (KR_keyword, "/dev/stdout", 11) == 0)
+                {
+{
+return dev_storage + 589;
+
+}
+                }
+              else
+                {
+{
+return	NULL;
+
+}
+                }
+            case 'c':
+              if (strncmp (KR_keyword, "/dev/conout", 11) == 0)
+                {
 {
 return dev_storage + 19;
+
+}
+                }
+              else
+                {
+{
+return	NULL;
+
+}
+                }
+            default:
+{
+return	NULL;
+
+}
+            }
+        case 'r':
+          if (strncmp (KR_keyword, "/dev/stderr", 11) == 0)
+            {
+{
+return dev_storage + 587;
 
 }
             }
@@ -9968,7 +10050,7 @@ return	NULL;
           if (strncmp (KR_keyword, "/dev/random", 11) == 0)
             {
 {
-return dev_storage + 425;
+return dev_storage + 426;
 
 }
             }
@@ -9989,7 +10071,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS99", 11) == 0)
                     {
 {
-return dev_storage + 686;
+return dev_storage + 690;
 
 }
                     }
@@ -10004,7 +10086,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS98", 11) == 0)
                     {
 {
-return dev_storage + 685;
+return dev_storage + 689;
 
 }
                     }
@@ -10019,7 +10101,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS97", 11) == 0)
                     {
 {
-return dev_storage + 684;
+return dev_storage + 688;
 
 }
                     }
@@ -10034,7 +10116,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS96", 11) == 0)
                     {
 {
-return dev_storage + 683;
+return dev_storage + 687;
 
 }
                     }
@@ -10049,7 +10131,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS95", 11) == 0)
                     {
 {
-return dev_storage + 682;
+return dev_storage + 686;
 
 }
                     }
@@ -10064,7 +10146,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS94", 11) == 0)
                     {
 {
-return dev_storage + 681;
+return dev_storage + 685;
 
 }
                     }
@@ -10079,7 +10161,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS93", 11) == 0)
                     {
 {
-return dev_storage + 680;
+return dev_storage + 684;
 
 }
                     }
@@ -10094,7 +10176,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS92", 11) == 0)
                     {
 {
-return dev_storage + 679;
+return dev_storage + 683;
 
 }
                     }
@@ -10109,7 +10191,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS91", 11) == 0)
                     {
 {
-return dev_storage + 678;
+return dev_storage + 682;
 
 }
                     }
@@ -10124,7 +10206,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS90", 11) == 0)
                     {
 {
-return dev_storage + 677;
+return dev_storage + 681;
 
 }
                     }
@@ -10316,7 +10398,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS89", 11) == 0)
                     {
 {
-return dev_storage + 676;
+return dev_storage + 680;
 
 }
                     }
@@ -10331,7 +10413,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS88", 11) == 0)
                     {
 {
-return dev_storage + 675;
+return dev_storage + 679;
 
 }
                     }
@@ -10346,7 +10428,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS87", 11) == 0)
                     {
 {
-return dev_storage + 674;
+return dev_storage + 678;
 
 }
                     }
@@ -10361,7 +10443,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS86", 11) == 0)
                     {
 {
-return dev_storage + 673;
+return dev_storage + 677;
 
 }
                     }
@@ -10376,7 +10458,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS85", 11) == 0)
                     {
 {
-return dev_storage + 672;
+return dev_storage + 676;
 
 }
                     }
@@ -10391,7 +10473,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS84", 11) == 0)
                     {
 {
-return dev_storage + 671;
+return dev_storage + 675;
 
 }
                     }
@@ -10406,7 +10488,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS83", 11) == 0)
                     {
 {
-return dev_storage + 670;
+return dev_storage + 674;
 
 }
                     }
@@ -10421,7 +10503,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS82", 11) == 0)
                     {
 {
-return dev_storage + 669;
+return dev_storage + 673;
 
 }
                     }
@@ -10436,7 +10518,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS81", 11) == 0)
                     {
 {
-return dev_storage + 668;
+return dev_storage + 672;
 
 }
                     }
@@ -10451,7 +10533,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS80", 11) == 0)
                     {
 {
-return dev_storage + 667;
+return dev_storage + 671;
 
 }
                     }
@@ -10643,7 +10725,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS79", 11) == 0)
                     {
 {
-return dev_storage + 666;
+return dev_storage + 670;
 
 }
                     }
@@ -10658,7 +10740,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS78", 11) == 0)
                     {
 {
-return dev_storage + 665;
+return dev_storage + 669;
 
 }
                     }
@@ -10673,7 +10755,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS77", 11) == 0)
                     {
 {
-return dev_storage + 664;
+return dev_storage + 668;
 
 }
                     }
@@ -10688,7 +10770,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS76", 11) == 0)
                     {
 {
-return dev_storage + 663;
+return dev_storage + 667;
 
 }
                     }
@@ -10703,7 +10785,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS75", 11) == 0)
                     {
 {
-return dev_storage + 662;
+return dev_storage + 666;
 
 }
                     }
@@ -10718,7 +10800,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS74", 11) == 0)
                     {
 {
-return dev_storage + 661;
+return dev_storage + 665;
 
 }
                     }
@@ -10733,7 +10815,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS73", 11) == 0)
                     {
 {
-return dev_storage + 660;
+return dev_storage + 664;
 
 }
                     }
@@ -10748,7 +10830,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS72", 11) == 0)
                     {
 {
-return dev_storage + 659;
+return dev_storage + 663;
 
 }
                     }
@@ -10763,7 +10845,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS71", 11) == 0)
                     {
 {
-return dev_storage + 658;
+return dev_storage + 662;
 
 }
                     }
@@ -10778,7 +10860,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS70", 11) == 0)
                     {
 {
-return dev_storage + 657;
+return dev_storage + 661;
 
 }
                     }
@@ -10970,7 +11052,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS69", 11) == 0)
                     {
 {
-return dev_storage + 656;
+return dev_storage + 660;
 
 }
                     }
@@ -10985,7 +11067,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS68", 11) == 0)
                     {
 {
-return dev_storage + 655;
+return dev_storage + 659;
 
 }
                     }
@@ -11000,7 +11082,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS67", 11) == 0)
                     {
 {
-return dev_storage + 654;
+return dev_storage + 658;
 
 }
                     }
@@ -11015,7 +11097,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS66", 11) == 0)
                     {
 {
-return dev_storage + 653;
+return dev_storage + 657;
 
 }
                     }
@@ -11030,7 +11112,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS65", 11) == 0)
                     {
 {
-return dev_storage + 652;
+return dev_storage + 656;
 
 }
                     }
@@ -11045,7 +11127,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS64", 11) == 0)
                     {
 {
-return dev_storage + 651;
+return dev_storage + 655;
 
 }
                     }
@@ -11060,7 +11142,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS63", 11) == 0)
                     {
 {
-return dev_storage + 650;
+return dev_storage + 654;
 
 }
                     }
@@ -11075,7 +11157,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS62", 11) == 0)
                     {
 {
-return dev_storage + 649;
+return dev_storage + 653;
 
 }
                     }
@@ -11090,7 +11172,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS61", 11) == 0)
                     {
 {
-return dev_storage + 648;
+return dev_storage + 652;
 
 }
                     }
@@ -11105,7 +11187,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS60", 11) == 0)
                     {
 {
-return dev_storage + 647;
+return dev_storage + 651;
 
 }
                     }
@@ -11297,7 +11379,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS59", 11) == 0)
                     {
 {
-return dev_storage + 646;
+return dev_storage + 650;
 
 }
                     }
@@ -11312,7 +11394,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS58", 11) == 0)
                     {
 {
-return dev_storage + 645;
+return dev_storage + 649;
 
 }
                     }
@@ -11327,7 +11409,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS57", 11) == 0)
                     {
 {
-return dev_storage + 644;
+return dev_storage + 648;
 
 }
                     }
@@ -11342,7 +11424,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS56", 11) == 0)
                     {
 {
-return dev_storage + 643;
+return dev_storage + 647;
 
 }
                     }
@@ -11357,7 +11439,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS55", 11) == 0)
                     {
 {
-return dev_storage + 642;
+return dev_storage + 646;
 
 }
                     }
@@ -11372,7 +11454,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS54", 11) == 0)
                     {
 {
-return dev_storage + 641;
+return dev_storage + 645;
 
 }
                     }
@@ -11387,7 +11469,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS53", 11) == 0)
                     {
 {
-return dev_storage + 640;
+return dev_storage + 644;
 
 }
                     }
@@ -11402,7 +11484,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS52", 11) == 0)
                     {
 {
-return dev_storage + 639;
+return dev_storage + 643;
 
 }
                     }
@@ -11417,7 +11499,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS51", 11) == 0)
                     {
 {
-return dev_storage + 638;
+return dev_storage + 642;
 
 }
                     }
@@ -11432,7 +11514,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS50", 11) == 0)
                     {
 {
-return dev_storage + 637;
+return dev_storage + 641;
 
 }
                     }
@@ -11624,7 +11706,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS49", 11) == 0)
                     {
 {
-return dev_storage + 636;
+return dev_storage + 640;
 
 }
                     }
@@ -11639,7 +11721,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS48", 11) == 0)
                     {
 {
-return dev_storage + 635;
+return dev_storage + 639;
 
 }
                     }
@@ -11654,7 +11736,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS47", 11) == 0)
                     {
 {
-return dev_storage + 634;
+return dev_storage + 638;
 
 }
                     }
@@ -11669,7 +11751,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS46", 11) == 0)
                     {
 {
-return dev_storage + 633;
+return dev_storage + 637;
 
 }
                     }
@@ -11684,7 +11766,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS45", 11) == 0)
                     {
 {
-return dev_storage + 632;
+return dev_storage + 636;
 
 }
                     }
@@ -11699,7 +11781,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS44", 11) == 0)
                     {
 {
-return dev_storage + 631;
+return dev_storage + 635;
 
 }
                     }
@@ -11714,7 +11796,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS43", 11) == 0)
                     {
 {
-return dev_storage + 630;
+return dev_storage + 634;
 
 }
                     }
@@ -11729,7 +11811,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS42", 11) == 0)
                     {
 {
-return dev_storage + 629;
+return dev_storage + 633;
 
 }
                     }
@@ -11744,7 +11826,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS41", 11) == 0)
                     {
 {
-return dev_storage + 628;
+return dev_storage + 632;
 
 }
                     }
@@ -11759,7 +11841,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS40", 11) == 0)
                     {
 {
-return dev_storage + 627;
+return dev_storage + 631;
 
 }
                     }
@@ -11951,7 +12033,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS39", 11) == 0)
                     {
 {
-return dev_storage + 626;
+return dev_storage + 630;
 
 }
                     }
@@ -11966,7 +12048,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS38", 11) == 0)
                     {
 {
-return dev_storage + 625;
+return dev_storage + 629;
 
 }
                     }
@@ -11981,7 +12063,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS37", 11) == 0)
                     {
 {
-return dev_storage + 624;
+return dev_storage + 628;
 
 }
                     }
@@ -11996,7 +12078,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS36", 11) == 0)
                     {
 {
-return dev_storage + 623;
+return dev_storage + 627;
 
 }
                     }
@@ -12011,7 +12093,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS35", 11) == 0)
                     {
 {
-return dev_storage + 622;
+return dev_storage + 626;
 
 }
                     }
@@ -12026,7 +12108,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS34", 11) == 0)
                     {
 {
-return dev_storage + 621;
+return dev_storage + 625;
 
 }
                     }
@@ -12041,7 +12123,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS33", 11) == 0)
                     {
 {
-return dev_storage + 620;
+return dev_storage + 624;
 
 }
                     }
@@ -12056,7 +12138,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS32", 11) == 0)
                     {
 {
-return dev_storage + 619;
+return dev_storage + 623;
 
 }
                     }
@@ -12071,7 +12153,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS31", 11) == 0)
                     {
 {
-return dev_storage + 618;
+return dev_storage + 622;
 
 }
                     }
@@ -12086,7 +12168,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS30", 11) == 0)
                     {
 {
-return dev_storage + 617;
+return dev_storage + 621;
 
 }
                     }
@@ -12278,7 +12360,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS29", 11) == 0)
                     {
 {
-return dev_storage + 616;
+return dev_storage + 620;
 
 }
                     }
@@ -12293,7 +12375,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS28", 11) == 0)
                     {
 {
-return dev_storage + 615;
+return dev_storage + 619;
 
 }
                     }
@@ -12308,7 +12390,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS27", 11) == 0)
                     {
 {
-return dev_storage + 614;
+return dev_storage + 618;
 
 }
                     }
@@ -12323,7 +12405,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS26", 11) == 0)
                     {
 {
-return dev_storage + 613;
+return dev_storage + 617;
 
 }
                     }
@@ -12338,7 +12420,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS25", 11) == 0)
                     {
 {
-return dev_storage + 612;
+return dev_storage + 616;
 
 }
                     }
@@ -12353,7 +12435,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS24", 11) == 0)
                     {
 {
-return dev_storage + 611;
+return dev_storage + 615;
 
 }
                     }
@@ -12368,7 +12450,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS23", 11) == 0)
                     {
 {
-return dev_storage + 610;
+return dev_storage + 614;
 
 }
                     }
@@ -12383,7 +12465,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS22", 11) == 0)
                     {
 {
-return dev_storage + 609;
+return dev_storage + 613;
 
 }
                     }
@@ -12398,7 +12480,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS21", 11) == 0)
                     {
 {
-return dev_storage + 608;
+return dev_storage + 612;
 
 }
                     }
@@ -12413,7 +12495,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS20", 11) == 0)
                     {
 {
-return dev_storage + 607;
+return dev_storage + 611;
 
 }
                     }
@@ -12437,7 +12519,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty127", 11) == 0)
                     {
 {
-return dev_storage + 424;
+return dev_storage + 425;
 
 }
                     }
@@ -12452,7 +12534,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty126", 11) == 0)
                     {
 {
-return dev_storage + 423;
+return dev_storage + 424;
 
 }
                     }
@@ -12467,7 +12549,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty125", 11) == 0)
                     {
 {
-return dev_storage + 422;
+return dev_storage + 423;
 
 }
                     }
@@ -12482,7 +12564,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty124", 11) == 0)
                     {
 {
-return dev_storage + 421;
+return dev_storage + 422;
 
 }
                     }
@@ -12497,7 +12579,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty123", 11) == 0)
                     {
 {
-return dev_storage + 420;
+return dev_storage + 421;
 
 }
                     }
@@ -12512,7 +12594,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty122", 11) == 0)
                     {
 {
-return dev_storage + 419;
+return dev_storage + 420;
 
 }
                     }
@@ -12527,7 +12609,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty121", 11) == 0)
                     {
 {
-return dev_storage + 418;
+return dev_storage + 419;
 
 }
                     }
@@ -12542,7 +12624,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty120", 11) == 0)
                     {
 {
-return dev_storage + 417;
+return dev_storage + 418;
 
 }
                     }
@@ -12566,7 +12648,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst127", 11) == 0)
                     {
 {
-return dev_storage + 294;
+return dev_storage + 295;
 
 }
                     }
@@ -12581,7 +12663,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst126", 11) == 0)
                     {
 {
-return dev_storage + 293;
+return dev_storage + 294;
 
 }
                     }
@@ -12596,7 +12678,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst125", 11) == 0)
                     {
 {
-return dev_storage + 292;
+return dev_storage + 293;
 
 }
                     }
@@ -12611,7 +12693,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst124", 11) == 0)
                     {
 {
-return dev_storage + 291;
+return dev_storage + 292;
 
 }
                     }
@@ -12626,7 +12708,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst123", 11) == 0)
                     {
 {
-return dev_storage + 290;
+return dev_storage + 291;
 
 }
                     }
@@ -12641,7 +12723,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst122", 11) == 0)
                     {
 {
-return dev_storage + 289;
+return dev_storage + 290;
 
 }
                     }
@@ -12656,7 +12738,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst121", 11) == 0)
                     {
 {
-return dev_storage + 288;
+return dev_storage + 289;
 
 }
                     }
@@ -12671,7 +12753,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst120", 11) == 0)
                     {
 {
-return dev_storage + 287;
+return dev_storage + 288;
 
 }
                     }
@@ -12863,7 +12945,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS19", 11) == 0)
                     {
 {
-return dev_storage + 606;
+return dev_storage + 610;
 
 }
                     }
@@ -12878,7 +12960,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS18", 11) == 0)
                     {
 {
-return dev_storage + 605;
+return dev_storage + 609;
 
 }
                     }
@@ -12893,7 +12975,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS17", 11) == 0)
                     {
 {
-return dev_storage + 604;
+return dev_storage + 608;
 
 }
                     }
@@ -12908,7 +12990,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS16", 11) == 0)
                     {
 {
-return dev_storage + 603;
+return dev_storage + 607;
 
 }
                     }
@@ -12923,7 +13005,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS15", 11) == 0)
                     {
 {
-return dev_storage + 602;
+return dev_storage + 606;
 
 }
                     }
@@ -12938,7 +13020,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS14", 11) == 0)
                     {
 {
-return dev_storage + 601;
+return dev_storage + 605;
 
 }
                     }
@@ -12953,7 +13035,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS13", 11) == 0)
                     {
 {
-return dev_storage + 600;
+return dev_storage + 604;
 
 }
                     }
@@ -12968,7 +13050,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS12", 11) == 0)
                     {
 {
-return dev_storage + 599;
+return dev_storage + 603;
 
 }
                     }
@@ -12983,7 +13065,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS11", 11) == 0)
                     {
 {
-return dev_storage + 598;
+return dev_storage + 602;
 
 }
                     }
@@ -12998,7 +13080,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS10", 11) == 0)
                     {
 {
-return dev_storage + 597;
+return dev_storage + 601;
 
 }
                     }
@@ -13022,7 +13104,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty119", 11) == 0)
                     {
 {
-return dev_storage + 416;
+return dev_storage + 417;
 
 }
                     }
@@ -13037,7 +13119,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty118", 11) == 0)
                     {
 {
-return dev_storage + 415;
+return dev_storage + 416;
 
 }
                     }
@@ -13052,7 +13134,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty117", 11) == 0)
                     {
 {
-return dev_storage + 414;
+return dev_storage + 415;
 
 }
                     }
@@ -13067,7 +13149,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty116", 11) == 0)
                     {
 {
-return dev_storage + 413;
+return dev_storage + 414;
 
 }
                     }
@@ -13082,7 +13164,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty115", 11) == 0)
                     {
 {
-return dev_storage + 412;
+return dev_storage + 413;
 
 }
                     }
@@ -13097,7 +13179,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty114", 11) == 0)
                     {
 {
-return dev_storage + 411;
+return dev_storage + 412;
 
 }
                     }
@@ -13112,7 +13194,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty113", 11) == 0)
                     {
 {
-return dev_storage + 410;
+return dev_storage + 411;
 
 }
                     }
@@ -13127,7 +13209,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty112", 11) == 0)
                     {
 {
-return dev_storage + 409;
+return dev_storage + 410;
 
 }
                     }
@@ -13142,7 +13224,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty111", 11) == 0)
                     {
 {
-return dev_storage + 408;
+return dev_storage + 409;
 
 }
                     }
@@ -13157,7 +13239,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty110", 11) == 0)
                     {
 {
-return dev_storage + 407;
+return dev_storage + 408;
 
 }
                     }
@@ -13181,7 +13263,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst119", 11) == 0)
                     {
 {
-return dev_storage + 286;
+return dev_storage + 287;
 
 }
                     }
@@ -13196,7 +13278,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst118", 11) == 0)
                     {
 {
-return dev_storage + 285;
+return dev_storage + 286;
 
 }
                     }
@@ -13211,7 +13293,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst117", 11) == 0)
                     {
 {
-return dev_storage + 284;
+return dev_storage + 285;
 
 }
                     }
@@ -13226,7 +13308,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst116", 11) == 0)
                     {
 {
-return dev_storage + 283;
+return dev_storage + 284;
 
 }
                     }
@@ -13241,7 +13323,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst115", 11) == 0)
                     {
 {
-return dev_storage + 282;
+return dev_storage + 283;
 
 }
                     }
@@ -13256,7 +13338,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst114", 11) == 0)
                     {
 {
-return dev_storage + 281;
+return dev_storage + 282;
 
 }
                     }
@@ -13271,7 +13353,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst113", 11) == 0)
                     {
 {
-return dev_storage + 280;
+return dev_storage + 281;
 
 }
                     }
@@ -13286,7 +13368,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst112", 11) == 0)
                     {
 {
-return dev_storage + 279;
+return dev_storage + 280;
 
 }
                     }
@@ -13301,7 +13383,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst111", 11) == 0)
                     {
 {
-return dev_storage + 278;
+return dev_storage + 279;
 
 }
                     }
@@ -13316,7 +13398,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst110", 11) == 0)
                     {
 {
-return dev_storage + 277;
+return dev_storage + 278;
 
 }
                     }
@@ -13508,7 +13590,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty109", 11) == 0)
                     {
 {
-return dev_storage + 406;
+return dev_storage + 407;
 
 }
                     }
@@ -13523,7 +13605,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty108", 11) == 0)
                     {
 {
-return dev_storage + 405;
+return dev_storage + 406;
 
 }
                     }
@@ -13538,7 +13620,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty107", 11) == 0)
                     {
 {
-return dev_storage + 404;
+return dev_storage + 405;
 
 }
                     }
@@ -13553,7 +13635,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty106", 11) == 0)
                     {
 {
-return dev_storage + 403;
+return dev_storage + 404;
 
 }
                     }
@@ -13568,7 +13650,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty105", 11) == 0)
                     {
 {
-return dev_storage + 402;
+return dev_storage + 403;
 
 }
                     }
@@ -13583,7 +13665,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty104", 11) == 0)
                     {
 {
-return dev_storage + 401;
+return dev_storage + 402;
 
 }
                     }
@@ -13598,7 +13680,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty103", 11) == 0)
                     {
 {
-return dev_storage + 400;
+return dev_storage + 401;
 
 }
                     }
@@ -13613,7 +13695,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty102", 11) == 0)
                     {
 {
-return dev_storage + 399;
+return dev_storage + 400;
 
 }
                     }
@@ -13628,7 +13710,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty101", 11) == 0)
                     {
 {
-return dev_storage + 398;
+return dev_storage + 399;
 
 }
                     }
@@ -13643,7 +13725,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/pty100", 11) == 0)
                     {
 {
-return dev_storage + 397;
+return dev_storage + 398;
 
 }
                     }
@@ -13667,7 +13749,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst109", 11) == 0)
                     {
 {
-return dev_storage + 276;
+return dev_storage + 277;
 
 }
                     }
@@ -13682,7 +13764,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst108", 11) == 0)
                     {
 {
-return dev_storage + 275;
+return dev_storage + 276;
 
 }
                     }
@@ -13697,7 +13779,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst107", 11) == 0)
                     {
 {
-return dev_storage + 274;
+return dev_storage + 275;
 
 }
                     }
@@ -13712,7 +13794,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst106", 11) == 0)
                     {
 {
-return dev_storage + 273;
+return dev_storage + 274;
 
 }
                     }
@@ -13727,7 +13809,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst105", 11) == 0)
                     {
 {
-return dev_storage + 272;
+return dev_storage + 273;
 
 }
                     }
@@ -13742,7 +13824,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst104", 11) == 0)
                     {
 {
-return dev_storage + 271;
+return dev_storage + 272;
 
 }
                     }
@@ -13757,7 +13839,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst103", 11) == 0)
                     {
 {
-return dev_storage + 270;
+return dev_storage + 271;
 
 }
                     }
@@ -13772,7 +13854,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst102", 11) == 0)
                     {
 {
-return dev_storage + 269;
+return dev_storage + 270;
 
 }
                     }
@@ -13787,7 +13869,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst101", 11) == 0)
                     {
 {
-return dev_storage + 268;
+return dev_storage + 269;
 
 }
                     }
@@ -13802,7 +13884,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/nst100", 11) == 0)
                     {
 {
-return dev_storage + 267;
+return dev_storage + 268;
 
 }
                     }
@@ -13838,7 +13920,7 @@ return	NULL;
           if (strncmp (KR_keyword, "/dev/windows", 12) == 0)
             {
 {
-return dev_storage + 716;
+return dev_storage + 720;
 
 }
             }
@@ -13853,7 +13935,7 @@ return	NULL;
           if (strncmp (KR_keyword, "/dev/urandom", 12) == 0)
             {
 {
-return dev_storage + 715;
+return dev_storage + 719;
 
 }
             }
@@ -13889,7 +13971,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS127", 12) == 0)
                     {
 {
-return dev_storage + 714;
+return dev_storage + 718;
 
 }
                     }
@@ -13904,7 +13986,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS126", 12) == 0)
                     {
 {
-return dev_storage + 713;
+return dev_storage + 717;
 
 }
                     }
@@ -13919,7 +14001,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS125", 12) == 0)
                     {
 {
-return dev_storage + 712;
+return dev_storage + 716;
 
 }
                     }
@@ -13934,7 +14016,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS124", 12) == 0)
                     {
 {
-return dev_storage + 711;
+return dev_storage + 715;
 
 }
                     }
@@ -13949,7 +14031,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS123", 12) == 0)
                     {
 {
-return dev_storage + 710;
+return dev_storage + 714;
 
 }
                     }
@@ -13964,7 +14046,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS122", 12) == 0)
                     {
 {
-return dev_storage + 709;
+return dev_storage + 713;
 
 }
                     }
@@ -13979,7 +14061,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS121", 12) == 0)
                     {
 {
-return dev_storage + 708;
+return dev_storage + 712;
 
 }
                     }
@@ -13994,7 +14076,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS120", 12) == 0)
                     {
 {
-return dev_storage + 707;
+return dev_storage + 711;
 
 }
                     }
@@ -14156,7 +14238,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS119", 12) == 0)
                     {
 {
-return dev_storage + 706;
+return dev_storage + 710;
 
 }
                     }
@@ -14171,7 +14253,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS118", 12) == 0)
                     {
 {
-return dev_storage + 705;
+return dev_storage + 709;
 
 }
                     }
@@ -14186,7 +14268,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS117", 12) == 0)
                     {
 {
-return dev_storage + 704;
+return dev_storage + 708;
 
 }
                     }
@@ -14201,7 +14283,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS116", 12) == 0)
                     {
 {
-return dev_storage + 703;
+return dev_storage + 707;
 
 }
                     }
@@ -14216,7 +14298,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS115", 12) == 0)
                     {
 {
-return dev_storage + 702;
+return dev_storage + 706;
 
 }
                     }
@@ -14231,7 +14313,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS114", 12) == 0)
                     {
 {
-return dev_storage + 701;
+return dev_storage + 705;
 
 }
                     }
@@ -14246,7 +14328,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS113", 12) == 0)
                     {
 {
-return dev_storage + 700;
+return dev_storage + 704;
 
 }
                     }
@@ -14261,7 +14343,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS112", 12) == 0)
                     {
 {
-return dev_storage + 699;
+return dev_storage + 703;
 
 }
                     }
@@ -14276,7 +14358,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS111", 12) == 0)
                     {
 {
-return dev_storage + 698;
+return dev_storage + 702;
 
 }
                     }
@@ -14291,7 +14373,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS110", 12) == 0)
                     {
 {
-return dev_storage + 697;
+return dev_storage + 701;
 
 }
                     }
@@ -14483,7 +14565,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS109", 12) == 0)
                     {
 {
-return dev_storage + 696;
+return dev_storage + 700;
 
 }
                     }
@@ -14498,7 +14580,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS108", 12) == 0)
                     {
 {
-return dev_storage + 695;
+return dev_storage + 699;
 
 }
                     }
@@ -14513,7 +14595,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS107", 12) == 0)
                     {
 {
-return dev_storage + 694;
+return dev_storage + 698;
 
 }
                     }
@@ -14528,7 +14610,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS106", 12) == 0)
                     {
 {
-return dev_storage + 693;
+return dev_storage + 697;
 
 }
                     }
@@ -14543,7 +14625,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS105", 12) == 0)
                     {
 {
-return dev_storage + 692;
+return dev_storage + 696;
 
 }
                     }
@@ -14558,7 +14640,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS104", 12) == 0)
                     {
 {
-return dev_storage + 691;
+return dev_storage + 695;
 
 }
                     }
@@ -14573,7 +14655,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS103", 12) == 0)
                     {
 {
-return dev_storage + 690;
+return dev_storage + 694;
 
 }
                     }
@@ -14588,7 +14670,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS102", 12) == 0)
                     {
 {
-return dev_storage + 689;
+return dev_storage + 693;
 
 }
                     }
@@ -14603,7 +14685,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS101", 12) == 0)
                     {
 {
-return dev_storage + 688;
+return dev_storage + 692;
 
 }
                     }
@@ -14618,7 +14700,7 @@ return	NULL;
                   if (strncmp (KR_keyword, "/dev/ttyS100", 12) == 0)
                     {
 {
-return dev_storage + 687;
+return dev_storage + 691;
 
 }
                     }

--- a/winsup/cygwin/devices.h
+++ b/winsup/cygwin/devices.h
@@ -70,6 +70,7 @@ enum fh_devices
   FH_NETDRIVE= FHDEV (DEV_VIRTFS_MAJOR, 194),
   FH_DEV     = FHDEV (DEV_VIRTFS_MAJOR, 193),
   FH_CYGDRIVE= FHDEV (DEV_VIRTFS_MAJOR, 192),
+  FH_DEV_FD  = FHDEV (DEV_VIRTFS_MAJOR, 191),
 
   FH_SIGNALFD= FHDEV (DEV_VIRTFS_MAJOR, 13),
   FH_TIMERFD = FHDEV (DEV_VIRTFS_MAJOR, 14),
@@ -436,7 +437,7 @@ extern const _device dev_fs_storage;
 #define isprocsys_dev(devn) (devn == FH_PROCSYS)
 
 #define isvirtual_dev(devn) \
-  (isproc_dev (devn) || devn == FH_CYGDRIVE || devn == FH_NETDRIVE)
+  (isproc_dev (devn) || devn == FH_CYGDRIVE || devn == FH_NETDRIVE || devn == FH_DEV_FD)
 
 #define iscons_dev(n) \
   ((device::major ((dev_t) (n)) == DEV_CONS_MAJOR) \

--- a/winsup/cygwin/devices.in
+++ b/winsup/cygwin/devices.in
@@ -175,6 +175,10 @@ const _device dev_error_storage =
 "/dev/fd%(0-15)d", BRACK(FHDEV(DEV_FLOPPY_MAJOR, {$1})), "\\Device\\Floppy{$1}", exists_ntdev, S_IFBLK
 "/dev/scd%(0-15)d", BRACK(FHDEV(DEV_CDROM_MAJOR, {$1})), "\\Device\\CdRom{$1}", exists_ntdev, S_IFBLK
 "/dev/sr%(0-15)d", BRACK(FHDEV(DEV_CDROM_MAJOR, {$1})), "\\Device\\CdRom{$1}", exists_ntdev, S_IFBLK
+"/dev/fd", BRACK(FH_DEV_FD), "/proc/self/fd", exists, S_IFLNK
+"/dev/stdin", BRACK(FH_DEV_FD), "/proc/self/fd/0", exists, S_IFLNK
+"/dev/stdout", BRACK(FH_DEV_FD), "/proc/self/fd/1", exists, S_IFLNK
+"/dev/stderr", BRACK(FH_DEV_FD), "/proc/self/fd/2", exists, S_IFLNK
 %other	{return	NULL;}
 %%
 #undef BRACK

--- a/winsup/cygwin/dtable.cc
+++ b/winsup/cygwin/dtable.cc
@@ -578,6 +578,9 @@ fh_alloc (path_conv& pc)
 	case FH_DEV:
 	  fh = cnew (fhandler_dev);
 	  break;
+	case FH_DEV_FD:
+	  fh = cnew (fhandler_dev_fd);
+	  break;
 	case FH_CYGDRIVE:
 	  fh = cnew (fhandler_cygdrive);
 	  break;

--- a/winsup/cygwin/fhandler.h
+++ b/winsup/cygwin/fhandler.h
@@ -2994,6 +2994,33 @@ class fhandler_procnet: public fhandler_proc
   }
 };
 
+class fhandler_dev_fd: public fhandler_virtual
+{
+ public:
+  fhandler_dev_fd ();
+  virtual_ftype_t exists();
+
+  int __reg2 fstat (struct stat *buf);
+  bool fill_filebuf ();
+
+  fhandler_dev_fd (void *) {}
+
+  virtual void copy_from (fhandler_base *x)
+  {
+    pc.free_strings ();
+    *this = *reinterpret_cast<fhandler_dev_fd *> (x);
+    _copy_from_reset_helper ();
+  }
+
+  virtual fhandler_dev_fd *clone (cygheap_types malloc_type = HEAP_FHANDLER)
+  {
+    void *ptr = (void *) ccalloc (malloc_type, 1, sizeof (fhandler_dev_fd));
+    fhandler_dev_fd *fh = new (ptr) fhandler_dev_fd (ptr);
+    fh->copy_from (this);
+    return fh;
+  }
+};
+
 class fhandler_signalfd : public fhandler_base
 {
   sigset_t sigset;
@@ -3193,6 +3220,7 @@ typedef union
   char __dev_raw[sizeof (fhandler_dev_raw)];
   char __dev_tape[sizeof (fhandler_dev_tape)];
   char __dev_zero[sizeof (fhandler_dev_zero)];
+  char __dev_fd[sizeof (fhandler_dev_fd)];
   char __disk_file[sizeof (fhandler_disk_file)];
   char __fifo[sizeof (fhandler_fifo)];
   char __netdrive[sizeof (fhandler_netdrive)];

--- a/winsup/cygwin/fhandler_dev_fd.cc
+++ b/winsup/cygwin/fhandler_dev_fd.cc
@@ -1,0 +1,53 @@
+/* fhandler_process_fd.cc: fhandler for the /dev/{fd,std{in,out,err}} symlinks
+
+This file is part of Cygwin.
+
+This software is a copyrighted work licensed under the terms of the
+Cygwin license.  Please consult the file "CYGWIN_LICENSE" for
+details. */
+
+#include "winsup.h"
+#include "path.h"
+#include "fhandler.h"
+
+fhandler_dev_fd::fhandler_dev_fd ():
+  fhandler_virtual ()
+{
+}
+
+virtual_ftype_t
+fhandler_dev_fd::exists ()
+{
+  return virt_symlink;
+}
+
+int __reg2
+fhandler_dev_fd::fstat (struct stat *buf)
+{
+  const char *path = get_name ();
+  debug_printf ("fstat (%s)", path);
+
+  fhandler_base::fstat (buf);
+
+  buf->st_mode = S_IFLNK | STD_RBITS | S_IWUSR | S_IWGRP | S_IWOTH | STD_XBITS;
+  buf->st_ino = get_ino ();
+
+  return 0;
+}
+
+bool
+fhandler_dev_fd::fill_filebuf ()
+{
+  const char *path = get_name ();
+  debug_printf ("fill_filebuf (%s)", path);
+
+  const char *native = get_native_name ();
+  if (!native)
+    {
+      return false;
+    }
+
+  free(filebuf);
+  filebuf = cstrdup (native);
+  return true;
+}


### PR DESCRIPTION
Let's avoid having to play games [in `setup-git-for-windows-sdk`](https://github.com/git-for-windows/setup-git-for-windows-sdk/blob/v1.1.2/main.ts#L90-L106) and in the Git for Windows installer that need to call `post-install.bat`, just to make sure that those four symlinks in `/dev/` exist: `fd`, `stdin`, `stdout` and `stderr`.

This also opens the door a little wider for offering Git for Windows as a Microsoft Store application. Only a little though.

This finally addresses [the challenge I offered to capable volunteers](https://github.com/git-for-windows/build-extra/pull/366#issuecomment-898567510).