### PR TITLE
Backport fix for hangup of less on quit after the window is resized.

### DIFF
--- a/winsup/cygwin/fhandler_console.cc
+++ b/winsup/cygwin/fhandler_console.cc
@@ -937,7 +937,11 @@ fhandler_console::send_winch_maybe ()
       con.scroll_region.Bottom = -1;
       if (wincap.has_con_24bit_colors () && !con_is_legacy)
 	fix_tab_position (get_output_handle ());
+      /* longjmp() may be called in the signal handler like less,
+	 so release input_mutex temporarily before kill_pgrp(). */
+      release_input_mutex ();
       get_ttyp ()->kill_pgrp (SIGWINCH);
+      acquire_input_mutex (mutex_timeout);
       return true;
     }
   return false;


### PR DESCRIPTION
This fixes https://github.com/git-for-windows/git/issues/4060
This fixes https://github.com/git-for-windows/git/issues/3438
This fixes https://github.com/git-for-windows/git/issues/3683