### PR TITLE
Avoid sharing cygheaps across Cygwin versions

### DIFF
--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -110,6 +110,11 @@ AC_CHECK_LIB([bfd], [bfd_init], [true],
 
 AM_CONDITIONAL(BUILD_DUMPER, [test "x$ac_cv_lib_bfd_bfd_init" = "xyes"])
 
+AC_CHECK_LIB([sframe], [sframe_decode],
+	     AC_MSG_NOTICE([Detected libsframe; Assuming that libbfd depends on it]), [true])
+
+AM_CONDITIONAL(HAVE_LIBSFRAME, [test "x$ac_cv_lib_sframe_sframe_decode" = "xyes"])
+
 AC_CONFIG_FILES([
     Makefile
     cygwin/Makefile

--- a/winsup/cygwin/dcrt0.cc
+++ b/winsup/cygwin/dcrt0.cc
@@ -545,7 +545,7 @@ get_cygwin_startup_info ()
   child_info *res = (child_info *) si.lpReserved2;
 
   if (si.cbReserved2 < EXEC_MAGIC_SIZE || !res
-      || res->intro != PROC_MAGIC_GENERIC || res->magic != CHILD_INFO_MAGIC)
+      || res->intro != PROC_MAGIC_GENERIC || res->magic != (CHILD_INFO_MAGIC ^ CYGWIN_VERSION_DLL_COMBINED))
     {
       strace.activate (false);
       res = NULL;

--- a/winsup/cygwin/sigproc.cc
+++ b/winsup/cygwin/sigproc.cc
@@ -817,7 +817,7 @@ int child_info::retry_count = 0;
    by fork/spawn/exec. */
 child_info::child_info (unsigned in_cb, child_info_types chtype,
 			bool need_subproc_ready):
-  cb (in_cb), intro (PROC_MAGIC_GENERIC), magic (CHILD_INFO_MAGIC),
+  cb (in_cb), intro (PROC_MAGIC_GENERIC), magic (CHILD_INFO_MAGIC ^ CYGWIN_VERSION_DLL_COMBINED),
   type (chtype), cygheap (::cygheap), cygheap_max (::cygheap_max),
   flag (0), retry (child_info::retry_count), rd_proc_pipe (NULL),
   wr_proc_pipe (NULL), sigmask (_my_tls.sigmask)

--- a/winsup/utils/Makefile.am
+++ b/winsup/utils/Makefile.am
@@ -87,6 +87,10 @@ profiler_CXXFLAGS = -I$(srcdir) -idirafter ${top_srcdir}/cygwin -idirafter ${top
 profiler_LDADD = $(LDADD) -lntdll
 cygps_LDADD = $(LDADD) -lpsapi -lntdll
 
+if HAVE_LIBSFRAME
+dumper_LDADD += -lsframe
+endif
+
 if CROSS_BOOTSTRAP
 SUBDIRS = mingw
 endif


### PR DESCRIPTION
It frequently leads to problems when trying, say, to call from Git for Windows' Bash into Cygwin's or MSYS2's, merely because sharing that data is pretty finicky.

For example, using the Git for Windows that is current at time of writing, trying to call MSYS2's Bash from Git for Windows' Bash fails somewhere in `_cmalloc()`, without any error message, and with the rather misleading exit code 127 (a code which is reserved to indicate that a command was not found).

Let's just treat these as completely incompatible with one another, by virtue of using a different `CHILD_INFO_MAGIC` constant.

One consequence is that spawned MSYS processes using a different MSYS2 runtime will not be visible as such to the parent process, i.e. they cannot share any resources such as pseudo terminals. But that's okay, they are simply treated as if they were regular Win32 programs.

This should also help the scenario where interactions between two different versions of Git for Windows lead to those infamous `cygheap base mismatch detected` problems mentioned e.g. in https://github.com/git-for-windows/git/issues/4255

This fixes https://github.com/git-for-windows/git/issues/4255