### PR TITLE
Prevent different msys2 runtime versions from sharing cygheaps, take two

### DIFF
--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -65,24 +65,30 @@ AC_ARG_WITH([msys2-runtime-commit],
 case "$MSYS2_RUNTIME_COMMIT" in
 no)
     MSYS2_RUNTIME_COMMIT=
+    MSYS2_RUNTIME_COMMIT_SHORT=
     MSYS2_RUNTIME_COMMIT_HEX=0
     ;;
 yes|auto)
     if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
     then
-        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+        MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
+        MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
     else
         AC_MSG_WARN([Could not determine msys2-runtime commit"])
         MSYS2_RUNTIME_COMMIT=
+        MSYS2_RUNTIME_COMMIT_SHORT=
         MSYS2_RUNTIME_COMMIT_HEX=0
     fi
     ;;
 *)
     expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
     AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
-    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+    MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
+    MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
     ;;
 esac
+AC_SUBST(MSYS2_RUNTIME_COMMIT)
+AC_SUBST(MSYS2_RUNTIME_COMMIT_SHORT)
 AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
 
 AC_ARG_ENABLE(debugging,

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -57,6 +57,34 @@ AC_CHECK_TOOL(RANLIB, ranlib, ranlib)
 AC_CHECK_TOOL(STRIP, strip, strip)
 AC_CHECK_TOOL(WINDRES, windres, windres)
 
+# Record msys2-runtime commit
+AC_ARG_WITH([msys2-runtime-commit],
+  [AS_HELP_STRING([--with-msys2-runtime-commit=COMMIT],
+		  [indicate the msys2-runtime commit corresponding to this build])],
+  [MSYS2_RUNTIME_COMMIT=$withval], [MSYS2_RUNTIME_COMMIT=yes])
+case "$MSYS2_RUNTIME_COMMIT" in
+no)
+    MSYS2_RUNTIME_COMMIT=
+    MSYS2_RUNTIME_COMMIT_HEX=0
+    ;;
+yes|auto)
+    if MSYS2_RUNTIME_COMMIT="$(git --git-dir="$srcdir/../.git" rev-parse HEAD)"
+    then
+        MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+    else
+        AC_MSG_WARN([Could not determine msys2-runtime commit"])
+        MSYS2_RUNTIME_COMMIT=
+        MSYS2_RUNTIME_COMMIT_HEX=0
+    fi
+    ;;
+*)
+    expr "$MSYS2_RUNTIME_COMMIT" : '@<:@0-9a-f@:>@\{6,64\}$' ||
+    AC_MSG_ERROR([Invalid commit name: "$MSYS2_RUNTIME_COMMIT"])
+    MSYS2_RUNTIME_COMMIT_HEX="0x$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')ull"
+    ;;
+esac
+AC_SUBST(MSYS2_RUNTIME_COMMIT_HEX)
+
 AC_ARG_ENABLE(debugging,
 [ --enable-debugging		Build a cygwin DLL which has more consistency checking for debugging],
 [case "${enableval}" in

--- a/winsup/cygwin/Makefile.am
+++ b/winsup/cygwin/Makefile.am
@@ -17,6 +17,9 @@ if TARGET_X86_64
 COMMON_CFLAGS+=-mcmodel=small
 endif
 
+VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
+COMMON_CFLAGS += $(VERSION_CFLAGS)
+
 AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
 AM_CXXFLAGS=$(cxxflags_common) $(COMMON_CFLAGS) -fno-threadsafe-statics
 

--- a/winsup/cygwin/Makefile.am
+++ b/winsup/cygwin/Makefile.am
@@ -17,7 +17,9 @@ if TARGET_X86_64
 COMMON_CFLAGS+=-mcmodel=small
 endif
 
-VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
+VERSION_CFLAGS = -DMSYS2_RUNTIME_COMMIT="\"@MSYS2_RUNTIME_COMMIT@\""
+VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_SHORT="\"@MSYS2_RUNTIME_COMMIT_SHORT@\""
+VERSION_CFLAGS += -DMSYS2_RUNTIME_COMMIT_HEX="@MSYS2_RUNTIME_COMMIT_HEX@"
 COMMON_CFLAGS += $(VERSION_CFLAGS)
 
 AM_CFLAGS=$(cflags_common) $(COMMON_CFLAGS)
@@ -408,7 +410,7 @@ src_files := $(foreach dir,$(dirs),$(find_src_files))
 version.cc: mkvers.sh include/cygwin/version.h winver.rc $(src_files)
 	@echo "Making version.cc and winver.o";\
 	export CC="$(CC)";\
-	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS)
+	/bin/sh $(word 1,$^) $(word 2,$^) $(word 3,$^) $(WINDRES) $(CFLAGS) $(VERSION_CFLAGS)
 
 winver.o: version.cc
 

--- a/winsup/cygwin/dcrt0.cc
+++ b/winsup/cygwin/dcrt0.cc
@@ -545,7 +545,7 @@ get_cygwin_startup_info ()
   child_info *res = (child_info *) si.lpReserved2;
 
   if (si.cbReserved2 < EXEC_MAGIC_SIZE || !res
-      || res->intro != PROC_MAGIC_GENERIC || res->magic != (CHILD_INFO_MAGIC ^ CYGWIN_VERSION_DLL_COMBINED))
+      || res->intro != PROC_MAGIC_GENERIC || res->magic != (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX))
     {
       strace.activate (false);
       res = NULL;

--- a/winsup/cygwin/mkvers.sh
+++ b/winsup/cygwin/mkvers.sh
@@ -16,6 +16,7 @@ incfile="$1"; shift
 rcfile="$1"; shift
 windres="$1"; shift
 iflags=
+msys2_runtime_commit=
 # Find header file locations
 while [ -n "$*" ]; do
   case "$1" in
@@ -26,6 +27,9 @@ while [ -n "$*" ]; do
     shift
     iflags="$iflags -I$1"
       ;;
+  -DMSYS2_RUNTIME_COMMIT=*)
+    msys2_runtime_commit="${1#*=}"
+    ;;
   esac
   shift
 done
@@ -184,6 +188,10 @@ if [ -n "$cvs_tag" ]
 then
   cvs_tag="$(echo $wv_cvs_tag | sed -e 's/-branch.*//')"
   cygwin_ver="$cygwin_ver-$cvs_tag"
+fi
+if [ -n "$msys2_runtime_commit" ]
+then
+  cygwin_ver="$cygwin_ver-$msys2_runtime_commit"
 fi
 
 echo "Version $cygwin_ver"

--- a/winsup/cygwin/sigproc.cc
+++ b/winsup/cygwin/sigproc.cc
@@ -817,7 +817,7 @@ int child_info::retry_count = 0;
    by fork/spawn/exec. */
 child_info::child_info (unsigned in_cb, child_info_types chtype,
 			bool need_subproc_ready):
-  cb (in_cb), intro (PROC_MAGIC_GENERIC), magic (CHILD_INFO_MAGIC ^ CYGWIN_VERSION_DLL_COMBINED),
+  cb (in_cb), intro (PROC_MAGIC_GENERIC), magic (CHILD_INFO_MAGIC ^ MSYS2_RUNTIME_COMMIT_HEX),
   type (chtype), cygheap (::cygheap), cygheap_max (::cygheap_max),
   flag (0), retry (child_info::retry_count), rd_proc_pipe (NULL),
   wr_proc_pipe (NULL), sigmask (_my_tls.sigmask)

--- a/winsup/cygwin/uname.cc
+++ b/winsup/cygwin/uname.cc
@@ -64,10 +64,11 @@ uname_x (struct utsname *name)
       cygwin_gethostname (buf, sizeof buf - 1);
       strncat (name->nodename, buf, sizeof (name->nodename) - 1);
       /* release */
-      __small_sprintf (name->release, "%d.%d.%d-%d.",
+      __small_sprintf (name->release, "%d.%d.%d-%s-%d.",
 		       cygwin_version.dll_major / 1000,
 		       cygwin_version.dll_major % 1000,
 		       cygwin_version.dll_minor,
+		       MSYS2_RUNTIME_COMMIT_SHORT,
 		       cygwin_version.api_minor);
       /* version */
       stpcpy (name->version, cygwin_version.dll_build_date);


### PR DESCRIPTION
This is a follow-up for #48 designed to address part of https://github.com/git-for-windows/git/issues/4305 by encoding the msys2-runtime commit in the magic constant used to figure out whether we can use "another MSYS2 runtime"'s cygheap or not.

At least in this developer's tests, adding the git-sdk-64's `usr/bin` to the `PATH` and fixed the exit code 127 seen when running `& 'C:\Program Files\Git\usr\bin\tar.exe' tzvf .\x.tgz` in a PowerShell.