### PR TITLE
Adjust CWD magic to accommodate for the latest Windows previews

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -4581,10 +4581,24 @@ find_fast_cwd_pointer ()
 	     or, then `mov %r12,%rcx', then `callq RtlEnterCriticalSection'. */
 	  lock = (const uint8_t *) memmem ((const char *) use_cwd, 80,
 					   "\x4c\x8d\x25", 3);
-	  if (!lock)
-	    return NULL;
 	  call_rtl_offset = 14;
 	}
+
+      if (!lock)
+	{
+	  /* A recent Windows Preview calls `lea rel(rip),%r13' then
+	     some unrelated instructions, then `callq RtlEnterCriticalSection'.
+	     */
+	  lock = (const uint8_t *) memmem ((const char *) use_cwd, 80,
+					   "\x4c\x8d\x2d", 3);
+	  call_rtl_offset = 24;
+	}
+
+      if (!lock)
+	{
+	  return NULL;
+	}
+
       PRTL_CRITICAL_SECTION lockaddr =
         (PRTL_CRITICAL_SECTION) (lock + 7 + peek32 (lock + 3));
       /* Test if lock address is FastPebLock. */


### PR DESCRIPTION
Reportedly Windows 11 build 25*** from Insider changed the current working directory logic a bit, and Cygwin's "magic" (or: "technologically sufficiently advanced") code needs to be adjusted accordingly.

This fixes https://github.com/git-for-windows/git/issues/4429