### PR TITLE
Fix `tar xf` with symlinks

### DIFF
--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -4580,7 +4580,7 @@ fchownat (int dirfd, const char *pathname, uid_t uid, gid_t gid, int flags)
       int res = gen_full_path_at (path, dirfd, pathname);
       if (res)
 	{
-	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
+	  if (!((errno == ENOENT || errno == ENOTDIR) && (flags & AT_EMPTY_PATH)))
 	    __leave;
 	  /* pathname is an empty string.  Operate on dirfd. */
 	  if (dirfd == AT_FDCWD)
@@ -4625,7 +4625,7 @@ fstatat (int dirfd, const char *__restrict pathname, struct stat *__restrict st,
       int res = gen_full_path_at (path, dirfd, pathname);
       if (res)
 	{
-	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
+	  if (!((errno == ENOENT || errno == ENOTDIR) && (flags & AT_EMPTY_PATH)))
 	    __leave;
 	  /* pathname is an empty string.  Operate on dirfd. */
 	  if (dirfd == AT_FDCWD)


### PR DESCRIPTION
When `tar xf` encounters a symbolic link, it seems to call `fstatat()` with a file descriptor referring to said symbolic link and a `pathname` that is empty. Apparently the intended behavior is to then operate on the symbolic link itself (i.e. not on its target, unlike `fstat()` would). This behavior was broken in Cygwin v3.4.7, and here is a fix for that bug.