### PR TITLE
Sync with upstream's `AT_EMPTY_PATH` patch series

### DIFF
--- a/newlib/libc/include/sys/_default_fcntl.h
+++ b/newlib/libc/include/sys/_default_fcntl.h
@@ -162,12 +162,13 @@ extern "C" {
 #define AT_FDCWD -2
 
 /* Flag values for faccessat2) et al. */
-#define AT_EACCESS              1
-#define AT_SYMLINK_NOFOLLOW     2
-#define AT_SYMLINK_FOLLOW       4
-#define AT_REMOVEDIR            8
+#define AT_EACCESS                 0x0001
+#define AT_SYMLINK_NOFOLLOW        0x0002
+#define AT_SYMLINK_FOLLOW          0x0004
+#define AT_REMOVEDIR               0x0008
 #if __GNU_VISIBLE
-#define AT_EMPTY_PATH          16
+#define AT_EMPTY_PATH              0x0010
+#define _AT_NULL_PATHNAME_ALLOWED  0x4000 /* Internal flag used by futimesat */
 #endif
 #endif
 

--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -4439,7 +4439,7 @@ gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
 	  cygheap_fdget cfd (dirfd);
 	  if (cfd < 0)
 	    return -1;
-	  if (!cfd->pc.isdir ())
+	  if (!cfd->pc.isdir () && !(flags & AT_EMPTY_PATH))
 	    {
 	      set_errno (ENOTDIR);
 	      return -1;
@@ -4450,6 +4450,8 @@ gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
 	{
 	  if (!*pathname)
 	    {
+	      if (flags & AT_EMPTY_PATH)
+		return 0;
 	      set_errno (ENOENT);
 	      return -1;
 	    }
@@ -4571,29 +4573,14 @@ fchownat (int dirfd, const char *pathname, uid_t uid, gid_t gid, int flags)
 	  __leave;
 	}
       char *path = tp.c_get ();
-      int res = gen_full_path_at (path, dirfd, pathname);
+      int res = gen_full_path_at (path, dirfd, pathname, flags);
       if (res)
+	__leave;
+      if (!*pathname) /* Implies AT_EMPTY_PATH */
 	{
-	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
-	    __leave;
-	  /* pathname is an empty string.  Operate on dirfd. */
-	  if (dirfd == AT_FDCWD)
-	    {
-	      cwdstuff::acquire_read ();
-	      strcpy (path, cygheap->cwd.get_posix ());
-	      cwdstuff::release_read ();
-	    }
-	  else
-	    {
-	      cygheap_fdget cfd (dirfd);
-	      if (cfd < 0)
-		__leave;
-	      strcpy (path, cfd->get_name ());
-	      /* If dirfd refers to a symlink (which was necessarily
-		 opened with O_PATH | O_NOFOLLOW), we must operate
-		 directly on that symlink.. */
-	      flags = AT_SYMLINK_NOFOLLOW;
-	    }
+	  /* If dirfd refers to a symlink (which was necessarily opened with
+	     O_PATH | O_NOFOLLOW), we must operate directly on that symlink. */
+	  flags = AT_SYMLINK_NOFOLLOW;
 	}
       return chown_worker (path, (flags & AT_SYMLINK_NOFOLLOW)
 				 ? PC_SYM_NOFOLLOW : PC_SYM_FOLLOW, uid, gid);
@@ -4616,21 +4603,9 @@ fstatat (int dirfd, const char *__restrict pathname, struct stat *__restrict st,
 	  __leave;
 	}
       char *path = tp.c_get ();
-      int res = gen_full_path_at (path, dirfd, pathname);
+      int res = gen_full_path_at (path, dirfd, pathname, flags);
       if (res)
-	{
-	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
-	    __leave;
-	  /* pathname is an empty string.  Operate on dirfd. */
-	  if (dirfd == AT_FDCWD)
-	    {
-	      cwdstuff::acquire_read ();
-	      strcpy (path, cygheap->cwd.get_posix ());
-	      cwdstuff::release_read ();
-	    }
-	  else
-	    return fstat (dirfd, st);
-	}
+	  __leave;
       path_conv pc (path, ((flags & AT_SYMLINK_NOFOLLOW)
 			   ? PC_SYM_NOFOLLOW : PC_SYM_FOLLOW)
 			  | PC_POSIX | PC_KEEP_HANDLE, stat_suffixes);

--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -4414,11 +4414,10 @@ pclose (FILE *fp)
 
 static int
 gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
-		  bool null_pathname_allowed = false)
+		  int flags = 0)
 {
-  /* Set null_pathname_allowed to true to allow GLIBC compatible behaviour
-     for NULL pathname.  Only used by futimesat. */
-  if (!pathname && !null_pathname_allowed)
+  /* futimesat allows a NULL pathname. */
+  if (!pathname && !(flags & _AT_NULL_PATHNAME_ALLOWED))
     {
       set_errno (EFAULT);
       return -1;
@@ -4676,7 +4675,7 @@ futimesat (int dirfd, const char *pathname, const struct timeval times[2])
   __try
     {
       char *path = tp.c_get ();
-      if (gen_full_path_at (path, dirfd, pathname, true))
+      if (gen_full_path_at (path, dirfd, pathname, _AT_NULL_PATHNAME_ALLOWED))
 	__leave;
       return utimes (path, times);
     }

--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -4447,11 +4447,6 @@ gen_full_path_at (char *path_ret, int dirfd, const char *pathname,
 	    }
 	  p = stpcpy (path_ret, cfd->get_name ());
 	}
-      if (!p)
-	{
-	  set_errno (ENOTDIR);
-	  return -1;
-	}
       if (pathname)
 	{
 	  if (!*pathname)

--- a/winsup/cygwin/syscalls.cc
+++ b/winsup/cygwin/syscalls.cc
@@ -4580,7 +4580,7 @@ fchownat (int dirfd, const char *pathname, uid_t uid, gid_t gid, int flags)
       int res = gen_full_path_at (path, dirfd, pathname);
       if (res)
 	{
-	  if (!((errno == ENOENT || errno == ENOTDIR) && (flags & AT_EMPTY_PATH)))
+	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
 	    __leave;
 	  /* pathname is an empty string.  Operate on dirfd. */
 	  if (dirfd == AT_FDCWD)
@@ -4625,7 +4625,7 @@ fstatat (int dirfd, const char *__restrict pathname, struct stat *__restrict st,
       int res = gen_full_path_at (path, dirfd, pathname);
       if (res)
 	{
-	  if (!((errno == ENOENT || errno == ENOTDIR) && (flags & AT_EMPTY_PATH)))
+	  if (!(errno == ENOENT && (flags & AT_EMPTY_PATH)))
 	    __leave;
 	  /* pathname is an empty string.  Operate on dirfd. */
 	  if (dirfd == AT_FDCWD)


### PR DESCRIPTION
This reflects https://inbox.sourceware.org/cygwin-patches/20230712120804.2992142-1-corinna-cygwin@cygwin.com/t/#u, which is a patch series that addresses more completely the `AT_EMPTY_PATH` problem we fixed in #54.