### PR TITLE
msys2-runtime: restore fast path for current user primary group

### DIFF
--- a/winsup/cygwin/include/sys/cygwin.h
+++ b/winsup/cygwin/include/sys/cygwin.h
@@ -219,7 +219,8 @@ enum
 enum
 {
   NSS_SRC_FILES = 1,
-  NSS_SRC_DB = 2
+  NSS_SRC_DB = 2,
+  NSS_SRC_DB_ACCURATE = 4
 };
 
 /* Enumeration source constants for CW_SETENT called from mkpasswd/mkgroup. */

--- a/winsup/cygwin/local_includes/cygheap.h
+++ b/winsup/cygwin/local_includes/cygheap.h
@@ -454,6 +454,7 @@ public:
   inline int  nss_pwd_src () const { return pwd_src; } /* CW_GETNSS_PWD_SRC */
   inline bool nss_grp_files () const { return !!(grp_src & NSS_SRC_FILES); }
   inline bool nss_grp_db () const { return !!(grp_src & NSS_SRC_DB); }
+  inline bool nss_grp_db_accurate () const { return !!(grp_src & NSS_SRC_DB_ACCURATE); }
   inline int  nss_grp_src () const { return grp_src; } /* CW_GETNSS_GRP_SRC */
   inline bool nss_cygserver_caching () const { return caching; }
   inline void nss_disable_cygserver_caching () { caching = false; }

--- a/winsup/doc/ntsec.xml
+++ b/winsup/doc/ntsec.xml
@@ -930,7 +930,16 @@ The two lines starting with the keywords <literal>passwd:</literal> and
 information from.  <literal>files</literal> means, fetch the information
 from the corresponding file in the /etc directory.  <literal>db</literal>
 means, fetch the information from the Windows account databases, the SAM
-for local accounts, Active Directory for domain account.  Examples:
+for local accounts, Active Directory for domain account.  For the current
+user, the default group is obtained from the current user token to avoid
+additional lookups to the group database. <literal>db-accuarte</literal> 
+is only valid on <literal>group:</literal> line, and performs the same 
+lookups as the <literal>db</literal> option, but disables using the
+current user token to retrieve the default group as this optimization
+is not accurate in all cases.  For example, if you run a native process
+with the primary group set to the Administrators builtin group, the 
+<literal>db</literal> option will return a non-existent group as primary
+group. Examples:
 </para>
 
 <screen>
@@ -947,6 +956,15 @@ Read passwd entries only from /etc/passwd.
 
 <para>
 Read group entries only from SAM/AD.
+</para>
+
+<screen>
+  group: db-accurate
+</screen>
+
+<para>
+Read group entries only from SAM/AD. Force the use of the group database
+for the current user.
 </para>
 
 <screen>


### PR DESCRIPTION
Commit a5bcfe616c7e8f78f464bf045595d8213244876a removed an optimization that fetches the default group from the current user token, as it is sometimes not accurate such as when groups like the builtin Administrators group is the primary group.

However, removing this optimization causes extremely poor performance when connected to some Active Directory environments.

Restored this optimization as the default behaviour, and added a `group: db-accurate` option to `nsswitch.conf` that can be used to disable the optimization in cases where accurate group information is required.

This fixes https://github.com/git-for-windows/git/issues/4459