### PR TITLE
Some backports from 3.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup-msys2
         uses: msys2/setup-msys2@v2
@@ -30,7 +30,7 @@ jobs:
           make DESTDIR="$(pwd)"/_dest install
 
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: install
           path: _dest/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,11 @@ jobs:
       - name: Build
         shell: msys2 {0}
         run: |
+          # XXX: cygwin still uses gcc v11 so we get new warnings with v13,
+          # resulting in errors. We can't selectively disable warnigns since our
+          # cross compiler is also too old and doesn't understand the new
+          # warning flags, so we need to disable all errors for now.
+          export CXXFLAGS="-Wno-error -Wno-narrowing"
           (cd winsup && ./autogen.sh)
           ./configure --disable-dependency-tracking
           make -j8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
         shell: msys2 {0}
         run: |
           (cd winsup && ./autogen.sh)
-          ./configure
+          ./configure --disable-dependency-tracking
           make -j8
 
       - name: Install

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -36,6 +36,7 @@ static char **lastenviron;
 /* Parse CYGWIN options */
 
 static NO_COPY bool export_settings = false;
+static bool emptyenvvalues = true;
 
 enum settings
   {
@@ -130,6 +131,7 @@ static struct parse_thing
   {"enable_pcon", {&disable_pcon}, setnegbool, NULL, {{true}, {false}}},
   {"winjitdebug", {&winjitdebug}, setbool, NULL, {{false}, {true}}},
   {"nativeinnerlinks", {&nativeinnerlinks}, setbool, NULL, {{false}, {true}}},
+  {"emptyenvvalues", {&emptyenvvalues}, setbool, NULL, {{false}, {true}}},
   {NULL, {0}, setdword, 0, {{0}, {0}}}
 };
 
@@ -1339,7 +1341,7 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
 	     Note that this doesn't stop invalid strings without '=' in it
 	     etc., but we're opting for speed here for now.  Adding complete
 	     checking would be pretty expensive. */
-	  if (len == 1)
+	  if (len == 1 || (!emptyenvvalues && !*rest))
 	    continue;
 
 	  /* See if this entry requires posix->win32 conversion. */

--- a/winsup/cygwin/environ.cc
+++ b/winsup/cygwin/environ.cc
@@ -1217,7 +1217,11 @@ build_env (const char * const *envp, PWCHAR &envblock, int &envc,
     {
       bool calc_tl = !no_envblock;
 #ifdef __MSYS__
-      if (!keep_posix)
+      if (ascii_strncasematch(*srcp, "MSYS=", 5))
+        {
+          parse_options (*srcp + 5);
+	}
+      else if (!keep_posix)
         {
           /* Don't pass timezone environment to non-msys applications */
           if (ascii_strncasematch(*srcp, "TZ=", 3))

--- a/winsup/cygwin/mount.cc
+++ b/winsup/cygwin/mount.cc
@@ -923,6 +923,9 @@ mount_info::conv_to_posix_path (const char *src_path, char *posix_path,
 	nextchar = 1;
 
       int addslash = nextchar > 0 ? 1 : 0;
+      /* avoid appending a slash if the result already has a trailing slash */
+      if (append_slash && mi.posix_pathlen && mi.posix_path[mi.posix_pathlen-1] == '/')
+	append_slash = addslash = 0;
       if ((mi.posix_pathlen + (pathbuflen - mi.native_pathlen) + addslash) >= NT_MAX_PATH)
 	return ENAMETOOLONG;
       strcpy (posix_path, mi.posix_path);

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -490,7 +490,7 @@ skip_p2w:
             if (isalpha(ch) && (*(it2+1) == ':') && (*(it2+2) == '/')) {
                 return SIMPLE_WINDOWS_PATH;
             }
-            if (ch == '/'&& memchr(it2, ',', end - it) == NULL) {
+            if (ch == '/'&& memchr(it2, ',', end - it2) == NULL) {
                 *src = it2;
                 return find_path_start_and_type(src, true, end);
             }
@@ -519,7 +519,7 @@ skip_p2w:
                         goto skip_p2w;
                     return POSIX_PATH_LIST;
                 }
-            } else if (memchr(it2, '=', end - it) == NULL) {
+            } else if (memchr(it2, '=', end - it2) == NULL) {
                 return SIMPLE_WINDOWS_PATH;
             }
         } else if (ch != '.') {

--- a/winsup/cygwin/msys2_path_conv.cc
+++ b/winsup/cygwin/msys2_path_conv.cc
@@ -406,6 +406,13 @@ skip_p2w:
 
     path_type result = NONE;
 
+    if (it + 1 == end) {
+        switch (*it) {
+        case '/':   return ROOTED_PATH ;
+        default:    return SIMPLE_WINDOWS_PATH;
+        }
+    }
+
     if (isalpha(*it) && *(it + 1) == ':') {
         if (*(it + 2) == '\\') {
             return SIMPLE_WINDOWS_PATH;

--- a/winsup/cygwin/nlsfuncs.cc
+++ b/winsup/cygwin/nlsfuncs.cc
@@ -255,8 +255,13 @@ rebase_locale_buf (const void *ptrv, const void *ptrvend, const char *newbase,
 {
   const char **ptrsend = (const char **) ptrvend;
   for (const char **ptrs = (const char **) ptrv; ptrs < ptrsend; ++ptrs)
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
     if (*ptrs >= oldbase && *ptrs < oldend)
       *ptrs += newbase - oldbase;
+#pragma GCC diagnostic pop
 }
 
 static wchar_t *
@@ -613,10 +618,15 @@ __set_lc_time_from_win (const char *name,
 		era = NULL;
 	      else
 		{
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
 		  if (tmp != new_lc_time_buf)
 		    rebase_locale_buf (_time_locale, _time_locale + 1, tmp,
 				       new_lc_time_buf, lc_time_ptr);
 		  lc_time_ptr = tmp + (lc_time_ptr - new_lc_time_buf);
+#pragma GCC diagnostic pop
 		  new_lc_time_buf = tmp;
 		  lc_time_end = new_lc_time_buf + len;
 		}
@@ -675,9 +685,14 @@ __set_lc_time_from_win (const char *name,
       free (new_lc_time_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_time_buf)
     rebase_locale_buf (_time_locale, _time_locale + 1, tmp,
 		       new_lc_time_buf, lc_time_ptr);
+#pragma GCC diagnostic pop
   *lc_time_buf = tmp;
   return 1;
 }
@@ -747,9 +762,14 @@ __set_lc_ctype_from_win (const char *name,
       free (new_lc_ctype_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_ctype_buf)
     rebase_locale_buf (_ctype_locale, _ctype_locale + 1, tmp,
 		       new_lc_ctype_buf, lc_ctype_ptr);
+#pragma GCC diagnostic pop
   *lc_ctype_buf = tmp;
   return 1;
 }
@@ -822,9 +842,14 @@ __set_lc_numeric_from_win (const char *name,
       free (new_lc_numeric_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_numeric_buf)
     rebase_locale_buf (_numeric_locale, _numeric_locale + 1, tmp,
 		       new_lc_numeric_buf, lc_numeric_ptr);
+#pragma GCC diagnostic pop
   *lc_numeric_buf = tmp;
   return 1;
 }
@@ -959,9 +984,14 @@ __set_lc_monetary_from_win (const char *name,
       free (new_lc_monetary_buf);
       return -1;
     }
+#pragma GCC diagnostic push
+#if __GNUC__ >= 12
+#pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif
   if (tmp != new_lc_monetary_buf)
     rebase_locale_buf (_monetary_locale, _monetary_locale + 1, tmp,
 		       new_lc_monetary_buf, lc_monetary_ptr);
+#pragma GCC diagnostic pop
   *lc_monetary_buf = tmp;
   return 1;
 }

--- a/winsup/cygwin/ntdll.h
+++ b/winsup/cygwin/ntdll.h
@@ -513,10 +513,12 @@ enum
   FILE_RENAME_IGNORE_READONLY_ATTRIBUTE			= 0x40
 };
 
+#if (__MINGW64_VERSION_MAJOR < 11)
 enum
 {
   FILE_CS_FLAG_CASE_SENSITIVE_DIR			= 0x01
 };
+#endif
 
 enum
 {


### PR DESCRIPTION
After merging https://github.com/git-for-windows/MSYS2-packages/pull/136, I realized that we had not kept the v3.3 branch up to date. So I went through the range-diff between the v3.3 and the v3.4 patches and cherry-picked anything from the latter that struck me as needing to be backported to the former.