### PR TITLE
Cygwin: pipe: Restore blocking mode of read pipe on close()

### DIFF
--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -1193,6 +1193,7 @@ private:
   uint64_t pipename_key;
   DWORD pipename_pid;
   LONG pipename_id;
+  bool was_blocking_read_pipe;
   void release_select_sem (const char *);
   HANDLE get_query_hdl_per_process (WCHAR *, OBJECT_NAME_INFORMATION *);
   HANDLE get_query_hdl_per_system (WCHAR *, OBJECT_NAME_INFORMATION *);


### PR DESCRIPTION
As of cygwin/cygwin@fc691d0246b9, which was backported to the `cygwin-3_5-branch` as https://github.com/cygwin/cygwin/commit/55431b408e7a6cb29d52ec619c38cdb6c40e2120, which in turn was backported into Git for Windows as a4d92d60dc, read pipes are essentially _always_ marked as non-blocking.

This strategy fails to take into account that pipes that were originally marked as blocking when they were created outside of MSYS/Cygwin are typically expected to remain in blocking mode by the processes that created them.

This leads to problems, e.g. the unfortunate symptom where using VSCode's built-in `askpass` helper, Git operations fail with this rather cryptic error message:

```
fatal: read error: Invalid argument
fatal: expected flush after ref listing
```

Work around this not by leaving the blocking/non-blocking mode alone, but instead by _still_ forcing the read pipe to non-blocking mode as long as Cygwin reads it _yet_ ensuring that the mode is restored when the MSYS/Cygwin end of the pipe is closed. This logic would not appear to be thread-safe in the hope that it does not matter in practice.

This addresses https://github.com/git-for-windows/git/issues/5115

/cc @tyan0