### PR TITLE
Fix SSH hangs

### DIFF
--- a/winsup/cygwin/select.cc
+++ b/winsup/cygwin/select.cc
@@ -776,7 +776,7 @@ out:
 	}
       ssize_t n = pipe_data_available (s->fd, fh, h, PDA_SELECT | PDA_WRITE);
       select_printf ("write: %s, n %d", fh->get_name (), n);
-      gotone += s->write_ready = (n >= PIPE_BUF);
+      gotone += s->write_ready = (n > 0);
       if (n < 0 && s->except_selected)
 	gotone += s->except_ready = true;
     }
@@ -990,7 +990,7 @@ out:
       ssize_t n = pipe_data_available (s->fd, fh, fh->get_handle (),
 				       PDA_SELECT | PDA_WRITE);
       select_printf ("write: %s, n %d", fh->get_name (), n);
-      gotone += s->write_ready = (n >= PIPE_BUF);
+      gotone += s->write_ready = (n > 0);
       if (n < 0 && s->except_selected)
 	gotone += s->except_ready = true;
     }
@@ -1416,7 +1416,7 @@ out:
     {
       ssize_t n = pipe_data_available (s->fd, fh, h, PDA_SELECT | PDA_WRITE);
       select_printf ("write: %s, n %d", fh->get_name (), n);
-      gotone += s->write_ready = (n >= PIPE_BUF);
+      gotone += s->write_ready = (n > 0);
       if (n < 0 && s->except_selected)
 	gotone += s->except_ready = true;
     }


### PR DESCRIPTION
Since upgrading the MSYS2 runtime to v3.5.4, cloning or fetching via SSH is hanging indefinitely.

Bisecting the problem points to 555afcb2f3 (Cygwin: select: set pipe writable only if PIPE_BUF bytes left, 2024-08-18), which we hereby essentially revert.

This fixes https://github.com/git-for-windows/git/issues/5199.