### PR TITLE
Cygwin: revert use of CancelSyncronousIo on wait_thread.

### DIFF
--- a/winsup/cygwin/pinfo.cc
+++ b/winsup/cygwin/pinfo.cc
@@ -1262,14 +1262,13 @@ proc_waiter (void *arg)
 
   for (;;)
     {
-      DWORD nb, err;
+      DWORD nb;
       char buf = '\0';
 
       if (!ReadFile (vchild.rd_proc_pipe, &buf, 1, &nb, NULL)
-	  && (err = GetLastError ()) != ERROR_BROKEN_PIPE)
+	  && GetLastError () != ERROR_BROKEN_PIPE)
 	{
-	  if (err != ERROR_OPERATION_ABORTED)
-	    system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
+	  system_printf ("error on read of child wait pipe %p, %E", vchild.rd_proc_pipe);
 	  break;
 	}
 

--- a/winsup/cygwin/sigproc.cc
+++ b/winsup/cygwin/sigproc.cc
@@ -410,8 +410,7 @@ proc_terminate ()
 	  if (!have_execed || !have_execed_cygwin)
 	    chld_procs[i]->ppid = 1;
 	  if (chld_procs[i].wait_thread)
-	    if (!CancelSynchronousIo (chld_procs[i].wait_thread->thread_handle ()))
-	      chld_procs[i].wait_thread->terminate_thread ();
+	    chld_procs[i].wait_thread->terminate_thread ();
 	  /* Release memory associated with this process unless it is 'myself'.
 	     'myself' is only in the chld_procs table when we've execed.  We
 	     reach here when the next process has finished initializing but we


### PR DESCRIPTION
It appears this is causing hangs on native x86_64 in similar scenarios as the hangs on ARM64, because `CancelSynchronousIo` is returning `TRUE` but not canceling the `ReadFile` call as expected.

Cherry-picked from msys2/msys2-runtime's 2eb6be14ee (Cygwin: revert use of CancelSyncronousIo on wait_thread., 2024-11-21).

This needs to be fast-tracked because Git v2.47.1 was released (surprisingly).