### PR TITLE
signal: Do not handle signal when __SIGFLUSHFAST is sent

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
           # resulting in errors due to -Werror. Disable them for now.
           export CXXFLAGS="-Wno-error=stringop-truncation -Wno-error=array-bounds -Wno-error=overloaded-virtual -Wno-narrowing -Wno-use-after-free -Wno-error=maybe-uninitialized"
           (cd winsup && ./autogen.sh)
-          ./configure --disable-dependency-tracking
+          ./configure --disable-dependency-tracking --with-msys2-runtime-commit=$GITHUB_SHA
           make -j8
 
       - name: Install

--- a/winsup/configure.ac
+++ b/winsup/configure.ac
@@ -74,7 +74,7 @@ yes|auto)
         MSYS2_RUNTIME_COMMIT_SHORT="$(expr "$MSYS2_RUNTIME_COMMIT" : '\(.\{,8\}\)')"
         MSYS2_RUNTIME_COMMIT_HEX="0x${MSYS2_RUNTIME_COMMIT_SHORT}ul"
     else
-        AC_MSG_WARN([Could not determine msys2-runtime commit"])
+        AC_MSG_WARN([Could not determine msys2-runtime commit])
         MSYS2_RUNTIME_COMMIT=
         MSYS2_RUNTIME_COMMIT_SHORT=
         MSYS2_RUNTIME_COMMIT_HEX=0

--- a/winsup/cygwin/release/3.5.6
+++ b/winsup/cygwin/release/3.5.6
@@ -1,0 +1,5 @@
+Fixes:
+------
+
+- Fix zsh hang at startup.
+  Addresses: https://cygwin.com/pipermail/cygwin/2024-December/256954.html

--- a/winsup/cygwin/sigproc.cc
+++ b/winsup/cygwin/sigproc.cc
@@ -751,10 +751,14 @@ sig_send (_pinfo *p, siginfo_t& si, _cygtls *tls)
       res = WriteFile (sendsig, leader, packsize, &nb, NULL);
       if (!res || packsize == nb)
 	break;
-      if (cygwait (NULL, 10, cw_sig_eintr) == WAIT_SIGNALED)
+      if (cygwait (NULL, 10, cw_sig_eintr) == WAIT_SIGNALED
+	  && pack.si.si_signo != __SIGFLUSHFAST)
 	_my_tls.call_signal_handler ();
       res = 0;
     }
+  /* Re-assert signal_arrived which has been cleared in cygwait(). */
+  if (_my_tls.sig)
+    _my_tls.set_signal_arrived ();
 
   if (!res)
     {
@@ -785,7 +789,16 @@ sig_send (_pinfo *p, siginfo_t& si, _cygtls *tls)
   if (wait_for_completion)
     {
       sigproc_printf ("Waiting for pack.wakeup %p", pack.wakeup);
-      rc = cygwait (pack.wakeup, WSSC);
+      do
+	{
+	  rc = cygwait (pack.wakeup, WSSC, cw_sig_eintr);
+	  if (rc == WAIT_SIGNALED && pack.si.si_signo != __SIGFLUSHFAST)
+	    _my_tls.call_signal_handler ();
+	}
+      while (rc != WAIT_OBJECT_0 && rc != WAIT_TIMEOUT);
+      /* Re-assert signal_arrived which has been cleared in cygwait(). */
+      if (_my_tls.sig)
+	_my_tls.set_signal_arrived ();
       ForceCloseHandle (pack.wakeup);
     }
   else
@@ -805,9 +818,6 @@ sig_send (_pinfo *p, siginfo_t& si, _cygtls *tls)
       set_errno (ENOSYS);
       rc = -1;
     }
-
-  if (wait_for_completion && si.si_signo != __SIGFLUSHFAST)
-    _my_tls.call_signal_handler ();
 
 out:
   if (communing && rc)


### PR DESCRIPTION
This hopefully will address [those hangs](https://github.com/git-for-windows/git-sdk-64/actions/runs/12488824371) in Git's test suite:

![image](https://github.com/user-attachments/assets/5ba4f3cf-e326-47c1-98c7-ad892acafa5d)
