### PR TITLE
Cygwin: Adjust CWD magic to accommodate for the latest Windows previews

### DIFF
--- a/winsup/cygwin/path.cc
+++ b/winsup/cygwin/path.cc
@@ -4794,6 +4794,18 @@ find_fast_cwd_pointer ()
          %rcx for the subsequent RtlEnterCriticalSection call. */
       lock = (const uint8_t *) memmem ((const char *) use_cwd, 80,
                                        "\x48\x8d\x0d", 3);
+      if (lock)
+	{
+	  /* A recent Windows 11 Preview calls `lea rel(rip),%rcx' then
+	     a `mov` and a `movups` instruction, and only then
+	     `callq RtlEnterCriticalSection'.
+	     */
+	  if (memmem (lock + 7, 8, "\x4c\x89\x78\x10\x0f\x11\x40\xc8", 8))
+	    {
+	      call_rtl_offset = 15;
+	    }
+	}
+
       if (!lock)
 	{
 	  /* Windows 8.1 Preview calls `lea rel(rip),%r12' then some unrelated


### PR DESCRIPTION
Reportedly a very recent internal build of Windows 11 once again changed the current working directory logic a bit, and Cygwin's "magic" (or: "technologically sufficiently advanced") code needs to be adjusted accordingly.

This fixes https://github.com/git-for-windows/git/issues/5447.