### PR TITLE
Cygwin: pipe: Fix hang due to inadvertent 0-length raw_write() and some signal fixes

### DIFF
--- a/winsup/cygwin/exceptions.cc
+++ b/winsup/cygwin/exceptions.cc
@@ -1807,6 +1807,13 @@ _cygtls::call_signal_handler ()
 	     to 16 byte. */
 	  uintptr_t new_sp = ((uintptr_t) _my_tls.altstack.ss_sp
 			      + _my_tls.altstack.ss_size) & ~0xf;
+	  /* Copy context1 to the alternate signal stack area, because the
+	     context1 allocated in the normal stack area is not accessible
+	     from the signal handler that uses alternate signal stack. */
+	  thiscontext = (ucontext_t *) ((new_sp - sizeof (ucontext_t)) & ~0xf);
+	  memcpy (thiscontext, &context1, sizeof (ucontext_t));
+	  new_sp = (uintptr_t) thiscontext;
+
 	  /* In assembler: Save regs on new stack, move to alternate stack,
 	     call thisfunc, revert stack regs. */
 #ifdef __x86_64__
@@ -1850,6 +1857,7 @@ _cygtls::call_signal_handler ()
 #else
 #error unimplemented for this target
 #endif
+	  memcpy (&context1, thiscontext, sizeof (ucontext_t));
 	}
       else
 	/* No alternate signal stack requested or available, just call

--- a/winsup/cygwin/fhandler/pipe.cc
+++ b/winsup/cygwin/fhandler/pipe.cc
@@ -1158,7 +1158,7 @@ fhandler_pipe::set_pipe_buf_size ()
   status = NtQueryInformationFile (get_handle (), &io, &fpli, sizeof fpli,
 				   FilePipeLocalInformation);
   if (NT_SUCCESS (status))
-    pipe_buf_size = fpli.InboundQuota;
+    pipe_buf_size = fpli.InboundQuota < PIPE_BUF ? PIPE_BUF : fpli.InboundQuota;
 }
 
 int

--- a/winsup/cygwin/release/3.6.1
+++ b/winsup/cygwin/release/3.6.1
@@ -3,3 +3,6 @@ Fixes:
 
 - Console mode is really restored to the previous mode.
   Addresses: https://github.com/msys2/msys2-runtime/issues/268
+
+- Clear direction flag in sigdeleyed before calling signal handler.
+  Addresses: https://cygwin.com/pipermail/cygwin/2025-March/257704.html

--- a/winsup/cygwin/release/3.6.1
+++ b/winsup/cygwin/release/3.6.1
@@ -6,3 +6,8 @@ Fixes:
 
 - Clear direction flag in sigdeleyed before calling signal handler.
   Addresses: https://cygwin.com/pipermail/cygwin/2025-March/257704.html
+
+- Copy context to alternate signal stack area in call_signal_handler()
+  in the SA_ONSTACK case, because locally-copied context on the normal
+  stack area is not accessible from the signal handler.
+  Addresses: https://cygwin.com/pipermail/cygwin/2025-March/257714.html

--- a/winsup/cygwin/scripts/gendef
+++ b/winsup/cygwin/scripts/gendef
@@ -179,6 +179,7 @@ sigdelayed:
 	movq	%rsp,%rbp
 	pushf
 	.seh_pushreg %rax			# fake, there's no .seh_pushreg for the flags
+	cld					# x86_64 ABI requires direction flag cleared
 	# stack is aligned or unaligned on entry!
 	# make sure it is aligned from here on
 	# We could be called from an interrupted thread which doesn't know


### PR DESCRIPTION
This is a companion of https://github.com/msys2/msys2-runtime/pull/271 and of https://inbox.sourceware.org/cygwin-patches/40a66dcf272eff407794bb94616d5b8ba833fafa.1743076896.git.johannes.schindelin@gmx.de/.

It also backports d71aeccff4d219b1cc7a6b0d17dcea7e5bb1b2e9 and 7f67575711f91ee0b738f836e2ed93c2e41b5248.

This closes https://github.com/git-for-windows/git/issues/5521 and https://github.com/git-for-windows/git/issues/5522.