### PR TITLE
Fix occasional hangs identified in MSYS2's CMake-based builds

### DIFF
--- a/winsup/cygwin/fork.cc
+++ b/winsup/cygwin/fork.cc
@@ -187,7 +187,6 @@ frok::child (volatile char * volatile here)
 
   ForceCloseHandle1 (fork_info->forker_finished, forker_finished);
 
-  pthread::atforkchild ();
   cygbench ("fork-child");
   ld_preload ();
   fixup_hooks_after_fork ();
@@ -199,6 +198,7 @@ frok::child (volatile char * volatile here)
   CloseHandle (hParent);
   hParent = NULL;
   cygwin_finished_initializing = true;
+  pthread::atforkchild ();
   return 0;
 }
 

--- a/winsup/cygwin/release/3.6.1
+++ b/winsup/cygwin/release/3.6.1
@@ -11,3 +11,8 @@ Fixes:
   in the SA_ONSTACK case, because locally-copied context on the normal
   stack area is not accessible from the signal handler.
   Addresses: https://cygwin.com/pipermail/cygwin/2025-March/257714.html
+
+- Move pthread::atforkchild() at the end of fork::child(). This fixes
+  subprocess failure in cmake (>= 3.29.x).
+  Addresses: https://cygwin.com/pipermail/cygwin/2025-March/257800.html
+  Addresses: https://github.com/msys2/msys2-runtime/issues/272


### PR DESCRIPTION
This corresponds to https://github.com/msys2/msys2-runtime/pull/274