### PR TITLE
Converted ui-tests workflow into test matrix that runs for windows-2022 and windows-2025

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -13,7 +13,14 @@ env:
 
 jobs:
   ui-tests:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Corresponds to Windows Server versions
+        # See https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+        os: [windows-2022, windows-2025]
+
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The ui-tests workflow previously only ran using the `windows-latest` runner, which maps onto Windows Server 2022 (based on Windows 10). This PR turns it into a test matrix that runs on Windows Server 2022 and Windows Server 2025 (based on Windows 11). 

I initially planned to add older Windows Server versions to check for backwards compatibility as well, but it looks like they are being deprecated by GitHub soon ([link](https://github.com/actions/runner-images/issues/12045)), so there's no point. 😅