### PR TITLE
Support AzureAD users again

### DIFF
--- a/winsup/cygwin/uinfo.cc
+++ b/winsup/cygwin/uinfo.cc
@@ -2002,10 +2002,6 @@ pwdgrp::fetch_account_from_windows (fetch_user_arg_t &arg, cyg_ldap *pldap)
       if (sid_id_auth (sid) == 5 /* SECURITY_NT_AUTHORITY */
 	  && sid_sub_auth (sid, 0) == SECURITY_APPPOOL_ID_BASE_RID)
 	break;
-      /* AzureAD SIDs */
-      if (sid_id_auth (sid) == 12 /* AzureAD ID */
-	  && sid_sub_auth (sid, 0) == 1 /* Azure ID base RID */)
-	break;
       /* Samba user/group SIDs */
       if (sid_id_auth (sid) == 22)
 	break;


### PR DESCRIPTION
As of the upgrade to v3.6.2, I can no longer open any MinTTY windows:

![image](https://private-user-images.githubusercontent.com/127790/450398391-7f807615-d4ce-48ae-bca9-06fbc48dc040.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDg4OTQ2NzcsIm5iZiI6MTc0ODg5NDM3NywicGF0aCI6Ii8xMjc3OTAvNDUwMzk4MzkxLTdmODA3NjE1LWQ0Y2UtNDhhZS1iY2E5LTA2ZmJjNDhkYzA0MC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjUwNjAyJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI1MDYwMlQxOTU5MzdaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT1hNDViMjBiOTU3M2ZjMWVhZmM4M2Q1YzVhNGE0OWY2MTVhMjVlMmU0ZjU2YmI2NjkyMDg1MGY1YzJmZDdiNWM3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.y2JlZ8qDmUrsPBA4rfPg37-tqGu8qCeW3LVunK_ZN-w)

This symptom (the message "Error: Could not fork child process: There are no available terminals (-1)") was also [described on the Cygwin mailing list](https://inbox.sourceware.org/cygwin/CAL148o6i=r+G=cEQzs5e+KmMt07FxJHhMnoNnquhM0JJuyrwtA@mail.gmail.com/#t).

I've bisected the problem down to 48e7d63268 (Cygwin: fetch_account_from_windows: skip LookupAccountSid for SIDs known to fail, 2025-04-10), which prevents my AzureAD user account (the SID begins with `S-1-12-1-`) from being handled correctly.

This PR is a (minimally) partial revert of that commit to resolve this problem, and a companion of https://github.com/msys2/msys2-runtime/pull/286.