### PR TITLE
Fix SSH hangs

### DIFF
--- a/winsup/cygwin/fhandler/pipe.cc
+++ b/winsup/cygwin/fhandler/pipe.cc
@@ -561,7 +561,7 @@ fhandler_pipe_fifo::raw_write (const void *ptr, size_t len)
       ULONG len1;
       DWORD waitret = WAIT_OBJECT_0;
 
-      if (left > chunk && !is_nonblocking ())
+      if (left > chunk && !real_non_blocking_mode)
 	len1 = chunk;
       else
 	len1 = (ULONG) left;


### PR DESCRIPTION
A report [demonstrated](https://github.com/git-for-windows/git/issues/5688#issuecomment-2990312559) that cloning large repositories via SSH frequently hangs:

```console
$ git clone https://github.com/SFML/SFML
Cloning into 'SFML'...
remote: Enumerating objects: 53694, done.
remote: Counting objects: 100% (620/620), done.
remote: Compressing objects: 100% (345/345), done.
Receiving objects:   7% (3759/53694)
```

and there it will stay.

This PR addresses that, and [has been contributed to the `cygwin-patches` mailing list](https://inbox.sourceware.org/cygwin-patches/c9b1313d5d8a690aae9788402ec5190a1f18ce75.1750679728.git.johannes.schindelin@gmx.de/) for review.