### PR TITLE
Allow Ctrl+C to interrupt clone via SSH again

### DIFF
--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -831,7 +831,7 @@ fhandler_console::set_input_mode (tty::cons_mode m, const termios *t,
       break;
     case tty::cygwin:
       flags |= ENABLE_WINDOW_INPUT;
-      if (con.master_thread_suspended)
+      if (con.master_thread_suspended || con.disable_master_thread)
 	flags |= ENABLE_PROCESSED_INPUT;
       if (wincap.has_con_24bit_colors () && !con_is_legacy)
 	flags |= ENABLE_VIRTUAL_TERMINAL_INPUT;


### PR DESCRIPTION
It was [reported](https://github.com/git-for-windows/git/issues/5688#issuecomment-3001536646) that a lengthy clone via SSH cannot be interrupted via Ctrl+C anymore.

This can be reproduced by cloning a large-ish repository via SSH, but even `C:\cygwin64\bin\sleep 10 < NUL` in a Windows Terminal will reproduce it.

I had reported this to the Cygwin developers and they fixed it, and in this PR here I cherry-pick the fix (cygwin/cygwin@61cc419b2b).