### PR TITLE
Upgrade Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
         # Cannot just grab from https://github.com/git-for-windows/git-sdk-64/releases/tag/ci-artifacts
         # because we also need the git-artifacts
         id: ci-artifacts-run-id
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const [ owner, repo ] = process.env.G4W_SDK_REPO.split('/')

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -76,7 +76,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/ahk" &&
           "$WINDIR/system32/tar.exe" -C "$RUNNER_TEMP/ahk" -xf "$RUNNER_TEMP/ahk.zip" &&
           cygpath -aw "$RUNNER_TEMP/ahk" >>$GITHUB_PATH
-      - uses: actions/setup-node@v4 # the hook uses node for the background process
+      - uses: actions/setup-node@v5 # the hook uses node for the background process
       - uses: actions/cache/restore@v4
         id: restore-win32-openssh
         with:


### PR DESCRIPTION
This supersedes #109 and #110, marking the changes to be squashed into the appropriate commits during the next rebase.