### PR TITLE
Cygwin: pty: detect pcon-backed pty for non-Cygwin-spawned children

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -116,6 +116,8 @@ jobs:
           if (!$?) { $exitCode = 1; echo "::error::Ctrl+C Test failed!" } else { echo "::notice::Ctrl+C Test log" }
           & "${env:RUNNER_TEMP}\ahk\AutoHotKey64.exe" /ErrorStdOut /force keystroke-order.ahk "$PWD\keystroke-order" 2>&1 | Out-Default
           if (!$?) { $exitCode = 1; echo "::error::Keystroke-order Test failed!" } else { echo "::notice::Keystroke-order Test log" }
+          & "${env:RUNNER_TEMP}\ahk\AutoHotKey64.exe" /ErrorStdOut /force pcon-grandchild-input.ahk "$PWD\pcon-grandchild-input" 2>&1 | Out-Default
+          if (!$?) { $exitCode = 1; echo "::error::pcon-grandchild-input Test failed!" } else { echo "::notice::pcon-grandchild-input Test log" }
           exit $exitCode
       - name: Show logs
         if: always()
@@ -124,6 +126,7 @@ jobs:
           type bg-hook.log
           type ctrl-c.log
           type keystroke-order.log
+          type pcon-grandchild-input.log
       - name: Take screenshot, if canceled
         id: take-screenshot
         if: cancelled() || failure()

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -190,6 +190,12 @@ jobs:
           $screen = [System.Windows.Forms.Screen]::PrimaryScreen
           $bounds = [Drawing.Rectangle]::FromLTRB(0, 0, $screen.Bounds.Width * $dpi / 96, $screen.Bounds.Height * $dpi / 96)
           screenshot $bounds "ui-tests/screenshot.png"
+      - name: Stop SSH server
+        if: always()
+        shell: powershell
+        run: |
+          Get-Process sshd -ErrorAction SilentlyContinue |
+            ForEach-Object { Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue }
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -118,6 +118,8 @@ jobs:
           if (!$?) { $exitCode = 1; echo "::error::Keystroke-order Test failed!" } else { echo "::notice::Keystroke-order Test log" }
           & "${env:RUNNER_TEMP}\ahk\AutoHotKey64.exe" /ErrorStdOut /force pcon-grandchild-input.ahk "$PWD\pcon-grandchild-input" 2>&1 | Out-Default
           if (!$?) { $exitCode = 1; echo "::error::pcon-grandchild-input Test failed!" } else { echo "::notice::pcon-grandchild-input Test log" }
+          & "${env:RUNNER_TEMP}\ahk\AutoHotKey64.exe" /ErrorStdOut /force pcon-tcflush.ahk "$PWD\pcon-tcflush" 2>&1 | Out-Default
+          if (!$?) { $exitCode = 1; echo "::error::pcon-tcflush Test failed!" } else { echo "::notice::pcon-tcflush Test log" }
           exit $exitCode
       - name: Show logs
         if: always()
@@ -127,6 +129,7 @@ jobs:
           type ctrl-c.log
           type keystroke-order.log
           type pcon-grandchild-input.log
+          type pcon-tcflush.log
       - name: Take screenshot, if canceled
         id: take-screenshot
         if: cancelled() || failure()

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -120,6 +120,8 @@ jobs:
           if (!$?) { $exitCode = 1; echo "::error::pcon-grandchild-input Test failed!" } else { echo "::notice::pcon-grandchild-input Test log" }
           & "${env:RUNNER_TEMP}\ahk\AutoHotKey64.exe" /ErrorStdOut /force pcon-tcflush.ahk "$PWD\pcon-tcflush" 2>&1 | Out-Default
           if (!$?) { $exitCode = 1; echo "::error::pcon-tcflush Test failed!" } else { echo "::notice::pcon-tcflush Test log" }
+          & "${env:RUNNER_TEMP}\ahk\AutoHotKey64.exe" /ErrorStdOut /force pcon-ctrl-c-cmd.ahk "$PWD\pcon-ctrl-c-cmd" 2>&1 | Out-Default
+          if (!$?) { $exitCode = 1; echo "::error::pcon-ctrl-c-cmd Test failed!" } else { echo "::notice::pcon-ctrl-c-cmd Test log" }
           exit $exitCode
       - name: Show logs
         if: always()
@@ -130,6 +132,7 @@ jobs:
           type keystroke-order.log
           type pcon-grandchild-input.log
           type pcon-tcflush.log
+          type pcon-ctrl-c-cmd.log
       - name: Take screenshot, if canceled
         id: take-screenshot
         if: cancelled() || failure()

--- a/ui-tests/ctrl-c.ahk
+++ b/ui-tests/ctrl-c.ahk
@@ -27,6 +27,8 @@ CloseWindow := true
 WinMove 0, 0
 Info 'Moved window to top left (so that the bottom is not cut off)'
 
+WaitForRegExInWindowsTerminal('PS [A-Z]:.*>[ `n`r]*$', 'Timed out waiting for PowerShell to start', 'PowerShell prompt appeared', 30000)
+
 ; sleep test
 Sleep 1500
 ; The `:;` is needed to force Git to call this via the shell, otherwise `/usr/bin/` would not resolve.

--- a/ui-tests/ctrl-c.ahk
+++ b/ui-tests/ctrl-c.ahk
@@ -91,6 +91,24 @@ if (openSSHPath != '' and FileExist(openSSHPath . '\sshd.exe')) {
             ExitWithError 'Could not add admin read permission from ' . path . ': ' A_LastError
     }
 
+    WaitForSshd() {
+        deadline := A_TickCount + 60000
+        while true {
+            if FileExist('sshd.pid') {
+                content := ''
+                try
+                    content := Trim(FileRead('sshd.pid'), ' `t`r`n')
+                if content != '' {
+                    Info('sshd is accepting connections (PID ' . content . ')')
+                    return
+                }
+            }
+            if A_TickCount > deadline
+                ExitWithError 'sshd did not write its PidFile within 60 seconds'
+            Sleep 500
+        }
+    }
+
     ; Set up SSH server
     Info('Generating host key')
     RunWait('git -c alias.c="!ssh-keygen -b 4096 -f ssh_host_rsa_key -N \"\"" c', '', 'Hide')
@@ -106,9 +124,11 @@ if (openSSHPath != '' and FileExist(openSSHPath . '\sshd.exe')) {
     AdjustPermissions('id_rsa.pub')
     FileAppend('Port 2322`n' .
         'HostKey "' . workTree . '\ssh_host_rsa_key"`n' .
-        'AuthorizedKeysFile "' . workTree . '\id_rsa.pub"`n',
+        'AuthorizedKeysFile "' . workTree . '\id_rsa.pub"`n' .
+        'LogLevel VERBOSE`n' .
+        'PidFile "' . workTree . '\sshd.pid"`n',
         'sshd_config')
-    sshdOptions := '-f "' . workTree . '\sshd_config" -D -d -d -d -E sshd.log'
+    sshdOptions := '-f "' . workTree . '\sshd_config" -D -E "' . workTree . '\sshd.log"'
 
     ; Start SSH server
     Info('Starting SSH server')
@@ -132,6 +152,7 @@ if (openSSHPath != '' and FileExist(openSSHPath . '\sshd.exe')) {
     ; `ssh.exe` prefixes the username with the domain name.
     cloneOptions := '--upload-pack="powershell git upload-pack" "' .
         EnvGet('USERNAME') . '@localhost:' . largeGitRepoPath . '" "' . largeGitClonePath . '"'
+    WaitForSshd()
     Send('git -c core.sshCommand="ssh ' . sshOptions . '" clone ' . cloneOptions . '{Enter}')
     Sleep 50
     Info('Waiting for clone to start')
@@ -177,6 +198,16 @@ if (openSSHPath != '' and FileExist(openSSHPath . '\sshd.exe')) {
 
     if not DirExist(largeGitClonePath)
         ExitWithError('`large-clone` did not work?!?')
+
+    for proc in ComObjGet('winmgmts:').ExecQuery('SELECT ProcessId, Name, ExecutablePath FROM Win32_Process WHERE Name LIKE "sshd%.exe"') {
+        if (proc.ExecutablePath != '' and InStr(proc.ExecutablePath, openSSHPath) > 0) {
+            Info('Stopping ' . proc.Name . ' (PID ' . proc.ProcessId . ')')
+            try {
+                ProcessClose proc.ProcessId
+                ProcessWaitClose proc.ProcessId, 5
+            }
+        }
+    }
 }
 
 Send('exit{Enter}')

--- a/ui-tests/pcon-ctrl-c-cmd.ahk
+++ b/ui-tests/pcon-ctrl-c-cmd.ahk
@@ -1,0 +1,169 @@
+#Requires AutoHotkey v2.0
+#Include ui-test-library.ahk
+
+; Reproducer for Takashi Yano's scenario (3) from
+; https://inbox.sourceware.org/cygwin-patches/20260508115113.6d73486274ab131bee493fe2@nifty.ne.jp/
+;
+;   "Run 'sleep 10' in cmd.exe and enter 'ps\n' while sleeping and
+;    press Ctrl-C.  'ps' will be executed after terminating 'sleep'
+;    by Ctrl-C."
+;
+; Yano's discard_input.patch (split here into two commits: "flush pcon
+; input buffer on tcflush() when pcon is active" and "keep Ctrl-C and
+; NOFLSH signal chars in the pcon input stream") fixes this jointly.
+;
+; The earlier (Y/N)?-batch-prompt and partial-line-cancel versions of
+; this test both passed equally against patched and unpatched runtimes;
+; cmd.exe's batch termination prompt and interactive line cancel are
+; both driven by CTRL_C_EVENT alone and don't require the stdin '\003'
+; byte that commit 4 enables.  Yano's exact scenario 3 is the closest
+; we have to a definitive repro of the combined fix.
+;
+; The test:
+;   1. launches cmd.exe under bash (activates pseudo console),
+;   2. starts a long-running Cygwin grandchild via the full Git-for-
+;      Windows path: c:\PROGRA~1\Git\usr\bin\sleep.exe 10,
+;   3. types a fresh command "echo TYPE_AHEAD_<marker><Enter>" while
+;      sleep is still running, so the bytes queue up wherever the
+;      runtime decides to route them,
+;   4. sends Ctrl-C to terminate sleep,
+;   5. types "echo FRESH_<marker><Enter>" once cmd.exe is responsive
+;      again,
+;   6. asserts FRESH_<marker> appears in cmd.exe's output (cmd.exe
+;      is alive),
+;   7. asserts TYPE_AHEAD_<marker> appears AT MOST ONCE in the
+;      captured buffer (i.e. just the typed echo command, NOT also
+;      cmd.exe's executed output of it).  If the type-ahead leaked
+;      through the runtime's signal handling and got executed by
+;      cmd.exe after sleep died, TYPE_AHEAD_<marker> shows up at
+;      least twice (typed + executed).
+
+SetWorkTree('git-test-pcon-ctrl-c-cmd')
+
+hwnd := LaunchMintty()
+winId := 'ahk_id ' hwnd
+
+; Wait for bash prompt.
+deadline := A_TickCount + 60000
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    if InStr(capture, '$ ')
+        break
+    Sleep 500
+}
+if !InStr(capture, '$ ')
+    ExitWithError 'Timed out waiting for bash prompt'
+Info 'Bash prompt appeared'
+
+; Launch cmd.exe.  Pcon activates the moment cmd.exe takes the
+; foreground.
+WinActivate(winId)
+SetKeyDelay 20, 20
+SendEvent('{Text}cmd.exe')
+SendEvent('{Enter}')
+
+deadline := A_TickCount + 10000
+cmdReady := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    if RegExMatch(capture, '[A-Z]:\\[^>\r\n]*>')
+    {
+        cmdReady := true
+        break
+    }
+    Sleep 500
+}
+if !cmdReady
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'cmd.exe prompt did not appear'
+}
+Info 'cmd.exe prompt appeared'
+
+typeAheadMarker := 'TYPE_AHEAD_LEAKED_KKK321'
+freshMarker := 'FRESH_LINE_OK_MMM456'
+
+; Start the long-running Cygwin grandchild.  10s is enough to type
+; the type-ahead and let it settle before the Ctrl-C.
+SendEvent('{Text}c:\PROGRA~1\Git\usr\bin\sleep.exe 10')
+SendEvent('{Enter}')
+Sleep 1500
+Info 'Sleep started'
+
+; Type a full command line WHILE sleep is still running.  In Yano's
+; scenario these bytes are buffered somewhere that the Ctrl-C-driven
+; teardown is supposed to clear; without the fix the buffered command
+; gets executed by cmd.exe once sleep is terminated.
+SendEvent('{Text}echo ' typeAheadMarker)
+SendEvent('{Enter}')
+Sleep 500
+Info 'Typed type-ahead command while sleep is running'
+
+; Now send Ctrl-C to terminate sleep.
+Send '{Ctrl down}c{Ctrl up}'
+Sleep 1500
+Info 'Sent Ctrl-C to terminate sleep'
+
+; Type a fresh command and execute it to confirm cmd.exe is alive
+; and to give any leaked type-ahead time to manifest in the buffer
+; before our assertion.
+SendEvent('{Text}echo ' freshMarker)
+SendEvent('{Enter}')
+
+deadline := A_TickCount + 10000
+freshOk := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    count := 0
+    searchPos := 1
+    while searchPos := InStr(capture, freshMarker, , searchPos)
+    {
+        count++
+        searchPos += StrLen(freshMarker)
+    }
+    if count >= 2
+    {
+        freshOk := true
+        break
+    }
+    Sleep 500
+}
+if !freshOk
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'cmd.exe did not execute the fresh command (input wedged?)'
+}
+Info 'cmd.exe executed the fresh command after Ctrl-C'
+
+; Critical assertion: the type-ahead command must NOT have been
+; executed.  If it leaked through, cmd.exe ran "echo TYPE_AHEAD_..."
+; and the marker appears at least twice (typed line + echoed output).
+capture := CaptureBufferFromMintty(winId)
+count := 0
+searchPos := 1
+while searchPos := InStr(capture, typeAheadMarker, , searchPos)
+{
+    count++
+    searchPos += StrLen(typeAheadMarker)
+}
+if count > 1
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'Type-ahead was executed by cmd.exe after Ctrl-C: ' typeAheadMarker ' appeared ' count ' times'
+}
+Info 'Type-ahead was successfully discarded by Ctrl-C'
+
+; Cleanup
+SendEvent('{Text}exit')
+SendEvent('{Enter}')
+Sleep 1000
+SendEvent('{Text}exit')
+SendEvent('{Enter}')
+Sleep 1000
+ExitApp 0

--- a/ui-tests/pcon-grandchild-input.ahk
+++ b/ui-tests/pcon-grandchild-input.ahk
@@ -1,0 +1,155 @@
+#Requires AutoHotkey v2.0
+#Include ui-test-library.ahk
+
+; Reproducer for the "cmd.exe input dies after a Cygwin grandchild exits"
+; bug fixed by:
+;
+;   Cygwin: pty: keep cmd.exe input alive after a Cygwin grandchild exits
+;
+; Scenario:
+;   bash (under mintty)
+;     -> cmd.exe   (activates pseudo console)
+;        -> ls.exe (Cygwin grandchild; opens the pty slave then exits)
+;
+; Before the fix, when ls.exe opens the slave, open_setup() duplicates the
+; cygwin master-side native pipe handles into the slave process; closing
+; the slave then closes those duplicates, which terminates cmd.exe's input
+; pipe.  After ls.exe exits, anything typed at cmd.exe is silently dropped.
+;
+; The test types into cmd.exe AFTER the Cygwin grandchild has finished and
+; asserts that the echoed text appears in the buffer.
+
+SetWorkTree('git-test-pcon-grandchild-input')
+
+hwnd := LaunchMintty()
+winId := 'ahk_id ' hwnd
+
+; Wait for bash prompt
+deadline := A_TickCount + 60000
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    if InStr(capture, '$ ')
+        break
+    Sleep 500
+}
+if !InStr(capture, '$ ')
+    ExitWithError 'Timed out waiting for bash prompt'
+Info 'Bash prompt appeared'
+
+; Launch cmd.exe to activate pseudo console
+WinActivate(winId)
+SetKeyDelay 20, 20
+SendEvent('{Text}cmd.exe')
+SendEvent('{Enter}')
+
+; Wait for cmd.exe prompt: it ends with "<drive>:\...>"
+deadline := A_TickCount + 10000
+cmdReady := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    if RegExMatch(capture, '[A-Z]:\\[^>\r\n]*>')
+    {
+        cmdReady := true
+        break
+    }
+    Sleep 500
+}
+if !cmdReady
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'cmd.exe prompt did not appear'
+}
+Info 'cmd.exe prompt appeared'
+
+; Run cat as a Cygwin grandchild that opens the pty slave and BLOCKS
+; on stdin until interrupted.  This matches Yano's bug report: it's
+; the Ctrl-C teardown of an interactive cygwin slave under cmd.exe,
+; not a quick non-interactive exit, that puts cmd.exe's input pipe
+; into the broken state the fix addresses.
+SendEvent('{Text}c:\PROGRA~1\Git\usr\bin\cat.exe')
+SendEvent('{Enter}')
+
+; Wait for cat to be obviously running by sending a probe line; cat
+; echoes back what it reads, so the second occurrence proves cat is
+; actively reading from the pty slave.
+Sleep 500
+catProbe := 'CAT_IS_LISTENING_HEY'
+SendEvent('{Text}' catProbe)
+SendEvent('{Enter}')
+
+deadline := A_TickCount + 10000
+catReady := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    count := 0
+    searchPos := 1
+    while searchPos := InStr(capture, catProbe, , searchPos)
+    {
+        count++
+        searchPos += StrLen(catProbe)
+    }
+    if count >= 2
+    {
+        catReady := true
+        break
+    }
+    Sleep 500
+}
+if !catReady
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'cat.exe did not echo back probe (not running as grandchild?)'
+}
+Info 'cat.exe is running and reading stdin'
+
+; Now interrupt cat with Ctrl-C; cat exits and the cygwin slave closes.
+; This is the moment that, without the fix, severs cmd.exe's pcon input.
+Send '{Ctrl down}c{Ctrl up}'
+Sleep 1500
+Info 'Sent Ctrl-C to cat'
+testMarker := 'POST_GRANDCHILD_OK_XYZ123'
+SendEvent('{Text}echo ' testMarker)
+SendEvent('{Enter}')
+
+deadline := A_TickCount + 10000
+inputOk := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    ; Both the command line and the echo output should contain the marker,
+    ; so count occurrences >= 2 to confirm the echo actually ran.
+    count := 0
+    searchPos := 1
+    while searchPos := InStr(capture, testMarker, , searchPos)
+    {
+        count++
+        searchPos += StrLen(testMarker)
+    }
+    if count >= 2
+    {
+        Info 'cmd.exe accepted input after Cygwin grandchild exited'
+        inputOk := true
+        break
+    }
+    Sleep 500
+}
+if !inputOk
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'cmd.exe input was lost after Cygwin grandchild exited'
+}
+
+; Clean up: exit cmd.exe, then exit bash.
+SendEvent('{Text}exit')
+SendEvent('{Enter}')
+Sleep 1000
+SendEvent('{Text}exit')
+SendEvent('{Enter}')
+Sleep 1000
+ExitApp 0

--- a/ui-tests/pcon-tcflush.ahk
+++ b/ui-tests/pcon-tcflush.ahk
@@ -1,0 +1,174 @@
+#Requires AutoHotkey v2.0
+#Include ui-test-library.ahk
+
+; Reproducer for the "tcflush() doesn't actually flush pcon input"
+; bug fixed by:
+;
+;   Cygwin: pty: flush pcon input buffer on tcflush() when pcon is active
+;
+; Scenario:
+;   bash (under mintty)
+;     -> cmd.exe                     (activates pseudo console)
+;        -> ping -n 30 localhost     (long-running, doesn't read stdin)
+;
+; While ping runs we type a "leaked-through" marker command into mintty;
+; mintty forwards those bytes into the pcon's input buffer, where they
+; sit because ping never reads them.  We then press Ctrl-C, which makes
+; Cygwin's master::write() observe '\003', synthesise CTRL_C_EVENT
+; (killing ping) and call discard_input() to drop pending input.
+;
+; Before the fix, discard_input() only drained Cygwin-side pipes; the
+; bytes still queued inside the pcon's own input buffer survived and were
+; handed to cmd.exe at the next prompt, so the marker command ran.  With
+; the fix discard_input() also calls FlushConsoleInputBuffer() on the
+; duplicated pcon input handle, so the marker is dropped.
+;
+; The test asserts the marker does NOT appear after Ctrl-C, and types a
+; fresh "after flush" marker to prove cmd.exe is still responsive (so a
+; missing leaked marker is genuinely due to the flush, not to cmd.exe
+; having silently died).
+
+SetWorkTree('git-test-pcon-tcflush')
+
+hwnd := LaunchMintty()
+winId := 'ahk_id ' hwnd
+
+; Wait for bash prompt
+deadline := A_TickCount + 60000
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    if InStr(capture, '$ ')
+        break
+    Sleep 500
+}
+if !InStr(capture, '$ ')
+    ExitWithError 'Timed out waiting for bash prompt'
+Info 'Bash prompt appeared'
+
+; Launch cmd.exe (activates pseudo console)
+WinActivate(winId)
+SetKeyDelay 20, 20
+SendEvent('{Text}cmd.exe')
+SendEvent('{Enter}')
+
+; Wait for cmd.exe prompt
+deadline := A_TickCount + 10000
+cmdReady := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    if RegExMatch(capture, '[A-Z]:\\[^>\r\n]*>')
+    {
+        cmdReady := true
+        break
+    }
+    Sleep 500
+}
+if !cmdReady
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'cmd.exe prompt did not appear'
+}
+Info 'cmd.exe prompt appeared'
+
+; Start a long-running foreground process that does NOT read stdin.
+; 30 pings at the default 1s interval gives us about 30 seconds.
+SendEvent('{Text}ping -n 30 localhost')
+SendEvent('{Enter}')
+
+deadline := A_TickCount + 10000
+pingStarted := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    if InStr(capture, 'Reply from') || InStr(capture, 'Pinging ')
+    {
+        pingStarted := true
+        break
+    }
+    Sleep 500
+}
+if !pingStarted
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'ping did not start'
+}
+Info 'ping is running'
+
+; Let ping run a moment so the prompt is gone and any typed bytes go
+; into the pcon's input buffer rather than being interpreted by cmd.exe.
+Sleep 1500
+
+leakMarker := 'TYPE_AHEAD_LEAKED_QQQ987'
+SendEvent('{Text}echo ' leakMarker)
+SendEvent('{Enter}')
+
+; Give the bytes a moment to reach the pcon's input buffer.
+Sleep 500
+
+; Ctrl-C: kills ping AND (with the fix) flushes pcon input.
+Send '{Ctrl down}c{Ctrl up}'
+
+; Sleep long enough for ping to die and the cmd.exe prompt to come
+; back, plus a bit extra so any UN-flushed type-ahead would have been
+; processed before our next probe.  We don't poll for the new prompt
+; because the old one is still in the buffer; instead the next typed
+; marker, by virtue of being echoed, will confirm cmd.exe is alive.
+Sleep 4000
+Info 'Slept past Ctrl-C; about to send post-flush probe'
+
+; Prove cmd.exe is still responsive: a fresh marker typed AFTER the
+; flush must reach cmd.exe and echo.  This rules out a "marker didn't
+; appear because cmd.exe is wedged" false pass for the next assertion.
+postMarker := 'AFTER_FLUSH_OK_RRR654'
+SendEvent('{Text}echo ' postMarker)
+SendEvent('{Enter}')
+
+deadline := A_TickCount + 10000
+postOk := false
+while A_TickCount < deadline
+{
+    capture := CaptureBufferFromMintty(winId)
+    count := 0
+    searchPos := 1
+    while searchPos := InStr(capture, postMarker, , searchPos)
+    {
+        count++
+        searchPos += StrLen(postMarker)
+    }
+    if count >= 2
+    {
+        postOk := true
+        break
+    }
+    Sleep 500
+}
+if !postOk
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'cmd.exe stopped accepting input after Ctrl-C'
+}
+Info 'cmd.exe is still responsive after the flush'
+
+; Critical assertion: the leaked-through marker must NOT appear anywhere.
+capture := CaptureBufferFromMintty(winId)
+if InStr(capture, leakMarker)
+{
+    Info 'Captured text:'
+    Info capture
+    ExitWithError 'pcon input was NOT flushed: ' leakMarker ' leaked through Ctrl-C'
+}
+Info 'pcon input was correctly flushed by Ctrl-C'
+
+; Clean up: exit cmd.exe, then bash.
+SendEvent('{Text}exit')
+SendEvent('{Enter}')
+Sleep 1000
+SendEvent('{Text}exit')
+SendEvent('{Enter}')
+Sleep 1000
+ExitApp 0

--- a/winsup/cygwin/dtable.cc
+++ b/winsup/cygwin/dtable.cc
@@ -327,7 +327,17 @@ dtable::init_std_file_from_handle (int fd, HANDLE handle)
 	dev.parse (myself->ctty);
       else
 	{
-	  dev.parse (FH_CONSOLE);
+	  /* Check whether the inherited console is actually a pseudo
+	     console bridging a pty.  This happens when our non-Cygwin
+	     parent was itself spawned by a Cygwin process from a pty
+	     (e.g. bash spawning git.exe which then spawns vim).  In
+	     that case, connect to the pty slave instead of treating
+	     the handle as a real console. */
+	  int pcon_minor = cygwin_shared->tty.find_pcon_pty ();
+	  if (pcon_minor >= 0)
+	    dev.parse (FHDEV (DEV_PTYS_MAJOR, pcon_minor));
+	  else
+	    dev.parse (FH_CONSOLE);
 	  CloseHandle (handle);
 	  handle = INVALID_HANDLE_VALUE;
 	}

--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -420,6 +420,7 @@ fhandler_console::cons_master_thread (handle_set_t *p, tty *ttyp)
 
       if (con.disable_master_thread)
 	{
+	  con.master_thread_suspended = true;
 	  cygwait (40);
 	  continue;
 	}
@@ -934,9 +935,9 @@ fhandler_console::setup_for_non_cygwin_app ()
      console mode. */
   if (get_ttyp ()->getpgid () == myself->pgid)
     {
+      set_disable_master_thread (true, this);
       set_input_mode (tty::native, &tc ()->ti, get_handle_set ());
       set_output_mode (tty::native, &tc ()->ti, get_handle_set ());
-      set_disable_master_thread (true, this);
     }
 }
 
@@ -948,12 +949,12 @@ fhandler_console::cleanup_for_non_cygwin_app (handle_set_t *p)
   termios *ti = shared_console_info[unit] ?
     &(shared_console_info[unit]->tty_min_state.ti) : &dummy;
   /* Cleaning-up console mode for non-cygwin app. */
-  set_disable_master_thread (con.owner == GetCurrentProcessId ());
   /* conmode can be tty::restore when non-cygwin app is
      exec'ed from login shell. */
   tty::cons_mode conmode = cons_mode_on_close (p);
   set_output_mode (conmode, ti, p);
   set_input_mode (conmode, ti, p);
+  set_disable_master_thread (con.owner == GetCurrentProcessId ());
 }
 
 /* Return the tty structure associated with a given tty number.  If the
@@ -1146,8 +1147,8 @@ fhandler_console::bg_check (int sig, bool dontsignal)
      in the same process group. */
   if (sig == SIGTTIN && con.curr_input_mode != tty::cygwin)
     {
-      set_disable_master_thread (false, this);
       set_input_mode (tty::cygwin, &tc ()->ti, get_handle_set ());
+      set_disable_master_thread (false, this);
     }
   if (sig == SIGTTOU && con.curr_output_mode != tty::cygwin)
     set_output_mode (tty::cygwin, &tc ()->ti, get_handle_set ());
@@ -2011,8 +2012,8 @@ fhandler_console::post_open_setup (int fd)
   /* Setting-up console mode for cygwin app started from non-cygwin app. */
   if (fd == 0)
     {
-      set_disable_master_thread (false, this);
       set_input_mode (tty::cygwin, &get_ttyp ()->ti, &handle_set);
+      set_disable_master_thread (false, this);
     }
   else if (fd == 1 || fd == 2)
     set_output_mode (tty::cygwin, &get_ttyp ()->ti, &handle_set);
@@ -2031,9 +2032,9 @@ fhandler_console::close (int flag)
       && (dev_t) myself->ctty == get_device ()
       && cons_mode_on_close (&handle_set) == tty::restore)
     {
+      set_disable_master_thread (true, this);
       set_output_mode (tty::restore, &get_ttyp ()->ti, &handle_set);
       set_input_mode (tty::restore, &get_ttyp ()->ti, &handle_set);
-      set_disable_master_thread (true, this);
     }
 
   if (shared_console_info[unit] && con.owner == GetCurrentProcessId ())
@@ -4357,10 +4358,10 @@ fhandler_console::set_console_mode_to_native ()
 	fhandler_console *cons = (fhandler_console *) (fhandler_base *) cfd;
 	if (cons->get_device () == cons->tc ()->getntty ())
 	  {
+	    set_disable_master_thread (true, cons);
 	    termios *cons_ti = &cons->tc ()->ti;
 	    set_input_mode (tty::native, cons_ti, cons->get_handle_set ());
 	    set_output_mode (tty::native, cons_ti, cons->get_handle_set ());
-	    set_disable_master_thread (true, cons);
 	    break;
 	  }
       }
@@ -4722,6 +4723,8 @@ fhandler_console::set_disable_master_thread (bool x, fhandler_console *cons)
   cons->acquire_input_mutex (mutex_timeout);
   con.disable_master_thread = x;
   cons->release_input_mutex ();
+  while (con.master_thread_suspended != x)
+    Sleep (1);
 }
 
 int

--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -1220,7 +1220,7 @@ wait_retry:
 
       int ret;
       acquire_input_mutex (mutex_timeout);
-      ret = process_input_message ();
+      ret = process_input_message (buflen);
       switch (ret)
 	{
 	case input_error:
@@ -1275,9 +1275,10 @@ sig_exit:
 }
 
 fhandler_console::input_states
-fhandler_console::process_input_message (void)
+fhandler_console::process_input_message (size_t len)
 {
   char tmp[60];
+  size_t num_chars = 0;
 
   if (!shared_console_info[unit])
     return input_error;
@@ -1652,6 +1653,7 @@ fhandler_console::process_input_message (void)
 	  continue;
 	}
 
+      num_chars += nread;
       if (toadd)
 	{
 	  ssize_t ret;
@@ -1669,15 +1671,22 @@ fhandler_console::process_input_message (void)
 		goto out;
 	    }
 	}
+      /* len == 0 if called from select.cc:peek_console() */
+      if (len && num_chars >= len)
+	goto out;
     }
 out:
+  if (len == 0)
+    /* If len == 0, cancel reading from console input buffer.
+       Clear readahead buffer. */
+    eat_readahead (-1);
   /* Discard processed recored. */
   DWORD discard_len = min (total_read, i + 1);
   /* If input is signalled, do not discard input here because
      tcflush() is already called from line_edit(). */
   if (stat == input_signalled && !(ti->c_lflag & NOFLSH))
     discard_len = 0;
-  if (discard_len)
+  if (discard_len && (len || stat != input_ok))
     {
       acquire_attach_mutex (mutex_timeout);
       DWORD resume_pid = attach_console (con.owner);

--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -949,12 +949,12 @@ fhandler_console::cleanup_for_non_cygwin_app (handle_set_t *p)
   termios *ti = shared_console_info[unit] ?
     &(shared_console_info[unit]->tty_min_state.ti) : &dummy;
   /* Cleaning-up console mode for non-cygwin app. */
+  set_disable_master_thread (con.owner == GetCurrentProcessId ());
   /* conmode can be tty::restore when non-cygwin app is
      exec'ed from login shell. */
   tty::cons_mode conmode = cons_mode_on_close (p);
   set_output_mode (conmode, ti, p);
   set_input_mode (conmode, ti, p);
-  set_disable_master_thread (con.owner == GetCurrentProcessId ());
 }
 
 /* Return the tty structure associated with a given tty number.  If the
@@ -1147,8 +1147,8 @@ fhandler_console::bg_check (int sig, bool dontsignal)
      in the same process group. */
   if (sig == SIGTTIN && con.curr_input_mode != tty::cygwin)
     {
-      set_input_mode (tty::cygwin, &tc ()->ti, get_handle_set ());
       set_disable_master_thread (false, this);
+      set_input_mode (tty::cygwin, &tc ()->ti, get_handle_set ());
     }
   if (sig == SIGTTOU && con.curr_output_mode != tty::cygwin)
     set_output_mode (tty::cygwin, &tc ()->ti, get_handle_set ());
@@ -2035,8 +2035,8 @@ fhandler_console::post_open_setup (int fd)
   /* Setting-up console mode for cygwin app started from non-cygwin app. */
   if (fd == 0)
     {
-      set_input_mode (tty::cygwin, &get_ttyp ()->ti, &handle_set);
       set_disable_master_thread (false, this);
+      set_input_mode (tty::cygwin, &get_ttyp ()->ti, &handle_set);
     }
   else if (fd == 1 || fd == 2)
     set_output_mode (tty::cygwin, &get_ttyp ()->ti, &handle_set);

--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -1653,6 +1653,7 @@ fhandler_console::process_input_message (size_t len)
 	  continue;
 	}
 
+      num_input_events_processed = i + 1;
       num_chars += nread;
       if (toadd)
 	{
@@ -1683,17 +1684,11 @@ out:
   /* Discard processed recored. */
   DWORD discard_len = min (total_read, i + 1);
   /* If input is signalled, do not discard input here because
-     tcflush() is already called from line_edit(). */
-  if (stat == input_signalled && !(ti->c_lflag & NOFLSH))
+     discard_key_events() is already called from line_edit(). */
+  if (stat == input_signalled)
     discard_len = 0;
   if (discard_len && (len || stat != input_ok))
-    {
-      acquire_attach_mutex (mutex_timeout);
-      DWORD resume_pid = attach_console (con.owner);
-      discard_key_events (discard_len);
-      detach_console (resume_pid, con.owner);
-      release_attach_mutex ();
-    }
+    discard_key_events (discard_len);
   return stat;
 }
 
@@ -1701,15 +1696,25 @@ void
 fhandler_console::discard_key_events (size_t n)
 {
   DWORD discarded = 0;
+  if (n == 0)
+    {
+      n = num_input_events_processed;
+      num_input_events_processed = 0;
+    }
   INPUT_RECORD input_rec[INREC_SIZE];
   DWORD n1 = min (INREC_SIZE, n);
+  acquire_attach_mutex (mutex_timeout);
+  DWORD resume_pid = attach_console (con.owner);
   while (n)
     {
-      ReadConsoleInputW (get_handle (), input_rec, n1, &n1);
+      if (!ReadConsoleInputW (get_handle (), input_rec, n1, &n1) || !n1)
+	break;
       n -= n1;
       discarded += n1;
       n1 = min (INREC_SIZE, n);
     }
+  detach_console (resume_pid, con.owner);
+  release_attach_mutex ();
   con.num_processed -= min (con.num_processed, discarded);
 }
 
@@ -2293,7 +2298,8 @@ fhandler_console::tcgetattr (struct termios *t)
 
 fhandler_console::fhandler_console (fh_devices devunit) :
   fhandler_termios (), input_ready (false), thread_sync_event (NULL),
-  input_mutex (NULL), output_mutex (NULL), unit (MAX_CONS_DEV)
+  input_mutex (NULL), output_mutex (NULL), unit (MAX_CONS_DEV),
+  num_input_events_processed (0)
 {
   dev_referred_via = (dev_t) devunit;
   if (devunit > 0)

--- a/winsup/cygwin/fhandler/console.cc
+++ b/winsup/cygwin/fhandler/console.cc
@@ -1679,15 +1679,29 @@ out:
     discard_len = 0;
   if (discard_len)
     {
-      DWORD discarded;
       acquire_attach_mutex (mutex_timeout);
       DWORD resume_pid = attach_console (con.owner);
-      ReadConsoleInputW (get_handle (), input_rec, discard_len, &discarded);
+      discard_key_events (discard_len);
       detach_console (resume_pid, con.owner);
       release_attach_mutex ();
-      con.num_processed -= min (con.num_processed, discarded);
     }
   return stat;
+}
+
+void
+fhandler_console::discard_key_events (size_t n)
+{
+  DWORD discarded = 0;
+  INPUT_RECORD input_rec[INREC_SIZE];
+  DWORD n1 = min (INREC_SIZE, n);
+  while (n)
+    {
+      ReadConsoleInputW (get_handle (), input_rec, n1, &n1);
+      n -= n1;
+      discarded += n1;
+      n1 = min (INREC_SIZE, n);
+    }
+  con.num_processed -= min (con.num_processed, discarded);
 }
 
 bool

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -1069,6 +1069,10 @@ fhandler_pty_slave::open_setup (int flags)
 void
 fhandler_pty_slave::cleanup ()
 {
+  fhandler_pty_slave *arch = (fhandler_pty_slave *) archetype ? : this;
+  while (arch->num_reader)
+    mask_switch_to_nat_pipe (false, false);
+
   if (get_ttyp ()->pcon_activated && get_ttyp ()->getpgid () == myself->pgid)
     req_fixup_pcon_state ();
 
@@ -1333,19 +1337,23 @@ fhandler_pty_slave::write (const void *ptr, size_t len)
 void
 fhandler_pty_slave::mask_switch_to_nat_pipe (bool mask, bool xfer)
 {
+  /* This input_mutex guard works as expected only because every
+     caller of transfer_input() holds input_mutex. This is a non-
+     local precondition. */
+  WaitForSingleObject (input_mutex, mutex_timeout);
   char name[MAX_PATH];
   shared_name (name, TTY_SLAVE_READING, get_minor ());
   HANDLE masked = OpenEvent (READ_CONTROL, FALSE, name);
   CloseHandle (masked);
 
-  WaitForSingleObject (input_mutex, mutex_timeout);
+  fhandler_pty_slave *arch = (fhandler_pty_slave *) archetype ? : this;
   if (mask)
     {
-      if (InterlockedIncrement (&num_reader) == 1)
-	slave_reading = CreateEvent (&sec_none_nih, TRUE, FALSE, name);
+      if (InterlockedIncrement (&arch->num_reader) == 1)
+	arch->slave_reading = CreateEvent (&sec_none_nih, TRUE, FALSE, name);
     }
-  else if (InterlockedDecrement (&num_reader) == 0)
-    CloseHandle (slave_reading);
+  else if (InterlockedDecrement (&arch->num_reader) == 0)
+    CloseHandle (arch->slave_reading);
 
   if (!!masked != mask && xfer && get_ttyp ()->switch_to_nat_pipe)
     {
@@ -4222,6 +4230,18 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
 				    HANDLE input_available_event,
 				    HANDLE input_transferred_to_cyg)
 {
+  if (dir == tty::to_nat)
+    {
+      char name[MAX_PATH];
+      shared_name (name, TTY_SLAVE_READING, ttyp->get_minor ());
+      HANDLE masked = OpenEvent (READ_CONTROL, FALSE, name);
+      CloseHandle (masked);
+      if (masked)
+	/* Cygwin process is reading cyg-pipe.
+	   Do not transfer input to nat-pipe. */
+	return;
+    }
+
   HANDLE to;
   if (dir == tty::to_nat)
     to = ttyp->to_slave_nat ();

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -492,8 +492,7 @@ fhandler_pty_master::accept_input ()
 
   HANDLE write_to = get_output_handle ();
   tmp_pathbuf tp;
-  if (to_be_read_from_nat_pipe ()
-      && get_ttyp ()->pty_input_state == tty::to_nat)
+  if (get_ttyp ()->pty_input_state == tty::to_nat)
     {
       /* This code is reached if non-cygwin app is foreground and
 	 pseudo console is not enabled. */
@@ -1113,18 +1112,18 @@ fhandler_pty_slave::reset_switch_to_nat_pipe (void)
 	  mutex_timeout = INFINITE;
 	  if (isHybrid)
 	    {
+	      WaitForSingleObject (input_mutex, mutex_timeout);
 	      if (get_ttyp ()->getpgid () == myself->pgid
 		  && GetStdHandle (STD_INPUT_HANDLE) == get_handle ()
 		  && get_ttyp ()->pty_input_state_eq (tty::to_nat))
 		{
-		  WaitForSingleObject (input_mutex, mutex_timeout);
 		  acquire_attach_mutex (mutex_timeout);
 		  transfer_input (tty::to_cyg, get_handle_nat (), get_ttyp (),
 				  input_available_event,
 				  input_transferred_to_cyg);
 		  release_attach_mutex ();
-		  ReleaseMutex (input_mutex);
 		}
+	      ReleaseMutex (input_mutex);
 	      if (get_ttyp ()->master_is_running_as_service
 		  && get_ttyp ()->pcon_activated)
 		/* If the master is running as service, re-attaching to
@@ -2199,6 +2198,22 @@ fhandler_pty_master::close (int flag)
   return 0;
 }
 
+line_edit_status
+fhandler_pty_master::line_edit_maybe (const char *ptr, size_t len,
+				      termios &ti, ssize_t *n)
+{
+  DWORD m;
+  if (get_ttyp ()->req_xfer_input
+      && get_ttyp ()->pty_input_state_eq (tty::to_nat))
+    {
+      WriteFile (to_slave_nat, ptr, len, &m, NULL);
+      *n = (ssize_t) m;
+      return line_edit_ok;
+    }
+  else
+    return line_edit (ptr, len, ti, n);
+}
+
 ssize_t
 fhandler_pty_master::write (const void *ptr, size_t len)
 {
@@ -2215,6 +2230,25 @@ fhandler_pty_master::write (const void *ptr, size_t len)
   push_process_state process_state (PID_TTYOU);
 
   get_ttyp ()->discard_input = false;
+
+  /* This input transfer is needed when cygwin-app which is started from
+     non-cygwin app is terminated while pseudo console is disabled. */
+  if (!get_ttyp ()->pcon_activated && !get_ttyp ()->pcon_start
+      && to_be_read_from_nat_pipe ())
+    {
+      WaitForSingleObject (input_mutex, mutex_timeout);
+      if (get_ttyp ()->nat_fg (get_ttyp ()->getpgid ())
+	  && get_ttyp ()->pty_input_state == tty::to_cyg)
+	{
+	  acquire_attach_mutex (mutex_timeout);
+	  fhandler_pty_slave::transfer_input (tty::to_nat, from_master,
+					      get_ttyp (),
+					      input_available_event,
+					      input_transferred_to_cyg);
+	  release_attach_mutex ();
+	}
+      ReleaseMutex (input_mutex);
+    }
 
   if (get_ttyp ()->pcon_start)
     { /* Reaches here when pseudo console initialization is on going. */
@@ -2236,7 +2270,7 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 	  if (p[i] == '\033')
 	    {
 	      if (ixput)
-		line_edit (wpbuf, ixput, ti, &ret);
+		line_edit_maybe (wpbuf, ixput, ti, &ret);
 	      ixput = 0;
 	      state = 1;
 	      wp_tid = _my_tls.thread_id;
@@ -2254,7 +2288,7 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 		}
 	    }
 	  else
-	    line_edit (p + i, 1, ti, &ret);
+	    line_edit_maybe (p + i, 1, ti, &ret);
 	  len = orig_len - i - 1;
 	  ptr = p + i + 1;
 	  if (state == 1 && wp_tid == _my_tls.thread_id && p[i] == 'R')
@@ -2277,6 +2311,7 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 
       if (!get_ttyp ()->pcon_start)
 	{ /* Pseudo console initialization has been done in above code. */
+	  WaitForSingleObject (input_mutex, mutex_timeout);
 	  pinfo pp (get_ttyp ()->pcon_start_pid);
 	  if (get_ttyp ()->switch_to_nat_pipe
 	      && pp && pp->pgid == get_ttyp ()->getpgid ()
@@ -2286,8 +2321,9 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 		{
 		  HANDLE pcon_handle_ready_event =
 		    get_ttyp ()->pcon_handle_ready_event;
-		  get_handle_from_process (get_ttyp ()->nat_pipe_owner_pid,
-					   pcon_handle_ready_event);
+		  pcon_handle_ready_event =
+		    get_handle_from_process (get_ttyp ()->nat_pipe_owner_pid,
+					     pcon_handle_ready_event);
 		  if (pcon_handle_ready_event)
 		    {
 		      cygwait (pcon_handle_ready_event, INFINITE);
@@ -2298,7 +2334,6 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 
 	      /* This accept_input() call is needed in order to transfer input
 		 which is not accepted yet to non-cygwin pipe. */
-	      WaitForSingleObject (input_mutex, mutex_timeout);
 	      if (get_readahead_valid ())
 		accept_input ();
 	      acquire_attach_mutex (mutex_timeout);
@@ -2307,9 +2342,9 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 						  input_available_event,
 						  input_transferred_to_cyg);
 	      release_attach_mutex ();
-	      ReleaseMutex (input_mutex);
 	    }
 	  get_ttyp ()->req_xfer_input = false;
+	  ReleaseMutex (input_mutex);
 	  get_ttyp ()->pcon_start_pid = 0;
 	}
       if (len == 0)
@@ -2319,7 +2354,7 @@ fhandler_pty_master::write (const void *ptr, size_t len)
   /* Write terminal input to to_slave_nat pipe instead of output_handle
      if current application is native console application. */
   WaitForSingleObject (input_mutex, mutex_timeout);
-  if (to_be_read_from_nat_pipe () && get_ttyp ()->pcon_activated
+  if (get_ttyp ()->pcon_activated
       && get_ttyp ()->pty_input_state == tty::to_nat)
     { /* Reaches here when non-cygwin app is foreground and pseudo console
 	 is activated. */
@@ -2403,20 +2438,6 @@ fhandler_pty_master::write (const void *ptr, size_t len)
   /* The code path reaches here when pseudo console is not activated
      or cygwin process is foreground even though pseudo console is
      activated. */
-
-  /* This input transfer is needed when cygwin-app which is started from
-     non-cygwin app is terminated if pseudo console is disabled. */
-  if (to_be_read_from_nat_pipe () && !get_ttyp ()->pcon_activated
-      && get_ttyp ()->nat_fg (get_ttyp ()->getpgid ())
-      && get_ttyp ()->pty_input_state == tty::to_cyg)
-    {
-      acquire_attach_mutex (mutex_timeout);
-      fhandler_pty_slave::transfer_input (tty::to_nat, from_master,
-					  get_ttyp (), input_available_event,
-					  input_transferred_to_cyg);
-      release_attach_mutex ();
-    }
-
   line_edit_status status = line_edit (p, len, ti, &ret);
   ReleaseMutex (input_mutex);
 
@@ -4363,9 +4384,9 @@ fhandler_pty_slave::setup_for_non_cygwin_app (bool nopcon,
 					      const WCHAR *envblock,
 					      bool stdin_is_ptys)
 {
+  WaitForSingleObject (pipe_sw_mutex, INFINITE);
   if (disable_pcon || !term_has_pcon_cap (envblock))
     nopcon = true;
-  WaitForSingleObject (pipe_sw_mutex, INFINITE);
   /* Setting switch_to_nat_pipe is necessary even if pseudo console
      will not be activated. */
   fhandler_base *fh = ::cygheap->fdtab[0];
@@ -4381,16 +4402,16 @@ fhandler_pty_slave::setup_for_non_cygwin_app (bool nopcon,
     pcon_enabled = setup_pseudoconsole ();
   ReleaseMutex (pipe_sw_mutex);
   /* For pcon enabled case, transfer_input() is called in master::write() */
+  WaitForSingleObject (input_mutex, mutex_timeout);
   if (!pcon_enabled && get_ttyp ()->getpgid () == myself->pgid
       && stdin_is_ptys && get_ttyp ()->pty_input_state_eq (tty::to_cyg))
     {
-      WaitForSingleObject (input_mutex, mutex_timeout);
       acquire_attach_mutex (mutex_timeout);
       transfer_input (tty::to_nat, get_handle (), get_ttyp (),
 		      input_available_event, input_transferred_to_cyg);
       release_attach_mutex ();
-      ReleaseMutex (input_mutex);
     }
+  ReleaseMutex (input_mutex);
 }
 
 void
@@ -4399,22 +4420,22 @@ fhandler_pty_slave::cleanup_for_non_cygwin_app (handle_set_t *p, tty *ttyp,
 						DWORD force_switch_to)
 {
   ttyp->wait_fwd ();
+  WaitForSingleObject (p->pipe_sw_mutex, INFINITE);
+  WaitForSingleObject (p->input_mutex, mutex_timeout);
   if (nat_pipe_owner_self (ttyp->nat_pipe_owner_pid))
     {
       DWORD switch_to = get_winpid_to_hand_over (ttyp, force_switch_to);
       if ((!switch_to && (ttyp->pcon_activated || stdin_is_ptys))
 	  && ttyp->pty_input_state_eq (tty::to_nat))
 	{
-	  WaitForSingleObject (p->input_mutex, mutex_timeout);
 	  acquire_attach_mutex (mutex_timeout);
 	  transfer_input (tty::to_cyg, p->from_master_nat, ttyp,
 			  p->input_available_event,
 			  p->input_transferred_to_cyg);
 	  release_attach_mutex ();
-	  ReleaseMutex (p->input_mutex);
 	}
     }
-  WaitForSingleObject (p->pipe_sw_mutex, INFINITE);
+  ReleaseMutex (p->input_mutex);
   if (ttyp->pcon_activated)
     close_pseudoconsole (ttyp, force_switch_to);
   else
@@ -4428,27 +4449,23 @@ fhandler_pty_slave::setpgid_aux (pid_t pid)
   reset_switch_to_nat_pipe ();
 
   WaitForSingleObject (pipe_sw_mutex, INFINITE);
+  WaitForSingleObject (input_mutex, mutex_timeout);
   bool was_nat_fg = get_ttyp ()->nat_fg (tc ()->pgid);
   bool nat_fg = get_ttyp ()->nat_fg (pid);
   if (!was_nat_fg && nat_fg && get_ttyp ()->switch_to_nat_pipe
       && get_ttyp ()->pty_input_state_eq (tty::to_cyg))
     {
-      ReleaseMutex (pipe_sw_mutex);
-      WaitForSingleObject (input_mutex, mutex_timeout);
       acquire_attach_mutex (mutex_timeout);
       transfer_input (tty::to_nat, get_handle (), get_ttyp (),
 		      input_available_event, input_transferred_to_cyg);
       release_attach_mutex ();
-      ReleaseMutex (input_mutex);
     }
   else if (was_nat_fg && !nat_fg && get_ttyp ()->switch_to_nat_pipe
 	   && get_ttyp ()->pty_input_state_eq (tty::to_nat))
     {
-      ReleaseMutex (pipe_sw_mutex);
       bool attach_restore = false;
       HANDLE from = get_handle_nat ();
       DWORD resume_pid = 0;
-      WaitForSingleObject (input_mutex, mutex_timeout);
       if (get_ttyp ()->pcon_activated && get_ttyp ()->nat_pipe_owner_pid
 	  && !get_console_process_id (get_ttyp ()->nat_pipe_owner_pid, true))
 	{
@@ -4466,10 +4483,9 @@ fhandler_pty_slave::setpgid_aux (pid_t pid)
 	resume_from_temporarily_attach (resume_pid);
       else
 	release_attach_mutex ();
-      ReleaseMutex (input_mutex);
     }
-  else
-    ReleaseMutex (pipe_sw_mutex);
+  ReleaseMutex (input_mutex);
+  ReleaseMutex (pipe_sw_mutex);
 }
 
 bool
@@ -4479,8 +4495,8 @@ fhandler_pty_master::need_send_ctrl_c_event ()
      apps will be done in pseudo console, therefore, sending it in
      fhandler_pty_master::write() duplicates that event for non-cygwin
      apps. So return false if pseudo console is activated. */
-  return !(to_be_read_from_nat_pipe () && get_ttyp ()->pcon_activated
-    && get_ttyp ()->pty_input_state == tty::to_nat);
+  return !(get_ttyp ()->pcon_activated
+	   && get_ttyp ()->pty_input_state == tty::to_nat);
 }
 
 void

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -274,12 +274,23 @@ fhandler_pty_slave::req_fixup_pcon_state (void)
 void
 fhandler_pty_master::fixup_pcon_cursor_position (int x, int y)
 {
+  /* A malformed or out-of-range reply must not be turned into a wrapped
+     negative COORD. */
+  if (x < 1 || y < 1 || x > 0x7fff || y > 0x7fff)
+    return;
   HANDLE pcon_owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE,
 				   get_ttyp ()->nat_pipe_owner_pid);
+  if (!pcon_owner)
+    /* The nat-pipe owner is gone; nothing to sync to. */
+    return;
   HANDLE h_pcon_out = NULL;
-  DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_out,
-		   GetCurrentProcess (), &h_pcon_out,
-		   0, TRUE, DUPLICATE_SAME_ACCESS);
+  if (!DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_out,
+			GetCurrentProcess (), &h_pcon_out,
+			0, TRUE, DUPLICATE_SAME_ACCESS))
+    {
+      CloseHandle (pcon_owner);
+      return;
+    }
   CloseHandle (pcon_owner);
   DWORD target_pid = get_ttyp ()->nat_pipe_owner_pid;
   DWORD resume_pid =
@@ -2432,8 +2443,8 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 	      if (get_ttyp ()->req_fixup_pcon_cur_pos)
 		{
 		  int x, y;
-		  sscanf (wpbuf, "\033[%d;%dR", &y, &x);
-		  fixup_pcon_cursor_position (x, y);
+		  if (sscanf (wpbuf, "\033[%d;%dR", &y, &x) == 2)
+		    fixup_pcon_cursor_position (x, y);
 		  get_ttyp ()->req_fixup_pcon_cur_pos = false;
 		}
 	      else if (!get_ttyp ()->req_xfer_input)

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -2044,6 +2044,23 @@ fhandler_pty_common::close (int flag)
   return 0;
 }
 
+static inline HANDLE
+get_handle_from_process (DWORD pid, HANDLE h, bool inh = false)
+{
+  HANDLE ret = NULL;
+  HANDLE owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE, pid);
+  if (owner)
+    {
+      if (!DuplicateHandle (owner, h, GetCurrentProcess (), &ret, 0, inh,
+			    DUPLICATE_SAME_ACCESS))
+	termios_printf ("DuplicateHandle() %p from process %d (%E)", h, pid);
+      CloseHandle (owner);
+    }
+  else
+    termios_printf ("OpenProcess (%d) failed (%E).", pid);
+  return ret;
+}
+
 void
 fhandler_pty_common::resize_pseudo_console (struct winsize *ws)
 {
@@ -2051,15 +2068,14 @@ fhandler_pty_common::resize_pseudo_console (struct winsize *ws)
   size.X = ws->ws_col;
   size.Y = ws->ws_row;
   HPCON_INTERNAL hpcon_local;
-  HANDLE pcon_owner =
-    OpenProcess (PROCESS_DUP_HANDLE, FALSE, get_ttyp ()->nat_pipe_owner_pid);
-  DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_write_pipe,
-		   GetCurrentProcess (), &hpcon_local.hWritePipe,
-		   0, FALSE, DUPLICATE_SAME_ACCESS);
+  hpcon_local.hWritePipe =
+    get_handle_from_process (get_ttyp ()->nat_pipe_owner_pid,
+			     get_ttyp ()->h_pcon_write_pipe);
+  if (hpcon_local.hWritePipe == NULL)
+    return;
   acquire_attach_mutex (mutex_timeout);
   ResizePseudoConsole ((HPCON) &hpcon_local, size);
   release_attach_mutex ();
-  CloseHandle (pcon_owner);
   CloseHandle (hpcon_local.hWritePipe);
 }
 
@@ -2313,18 +2329,13 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 	    {
 	      if (h_pcon_in_dupped)
 		ForceCloseHandle (h_pcon_in_dupped);
-	      h_pcon_in_dupped = NULL;
-	      nat_pipe_owner_pid_dupped = 0;
-	      HANDLE pcon_owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE,
-					       get_ttyp ()->nat_pipe_owner_pid);
-	      if (pcon_owner)
-		{
-		  DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_in,
-				   GetCurrentProcess (), &h_pcon_in_dupped,
-				   0, FALSE, DUPLICATE_SAME_ACCESS);
-		  nat_pipe_owner_pid_dupped = get_ttyp ()->nat_pipe_owner_pid;
-		  CloseHandle (pcon_owner);
-		}
+	      h_pcon_in_dupped =
+		get_handle_from_process (get_ttyp ()->nat_pipe_owner_pid,
+					 get_ttyp ()->h_pcon_in);
+	      if (h_pcon_in_dupped)
+		nat_pipe_owner_pid_dupped = get_ttyp ()->nat_pipe_owner_pid;
+	      else
+		nat_pipe_owner_pid_dupped = 0;
 	    }
 	  else
 	    {
@@ -4087,16 +4098,9 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
     to = ttyp->to_slave ();
 
   pinfo p (ttyp->master_pid);
-  HANDLE pty_owner = NULL;
   if (p)
-    pty_owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE, p->dwProcessId);
-  if (pty_owner)
-    {
-      DuplicateHandle (pty_owner, to, GetCurrentProcess (), &to,
-		       0, TRUE, DUPLICATE_SAME_ACCESS);
-      CloseHandle (pty_owner);
-    }
-  else
+    to = get_handle_from_process (p->dwProcessId, to, true);
+  if (to == NULL)
     {
       char pipe[MAX_PATH];
       __small_sprintf (pipe,
@@ -4397,12 +4401,8 @@ fhandler_pty_slave::setpgid_aux (pid_t pid)
       if (get_ttyp ()->pcon_activated && get_ttyp ()->nat_pipe_owner_pid
 	  && !get_console_process_id (get_ttyp ()->nat_pipe_owner_pid, true))
 	{
-	  HANDLE pcon_owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE,
-					   get_ttyp ()->nat_pipe_owner_pid);
-	  DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_in,
-			   GetCurrentProcess (), &from,
-			   0, TRUE, DUPLICATE_SAME_ACCESS);
-	  CloseHandle (pcon_owner);
+	  from = get_handle_from_process (get_ttyp ()->nat_pipe_owner_pid,
+					  get_ttyp ()->h_pcon_in, true);
 	  DWORD target_pid = get_ttyp ()->nat_pipe_owner_pid;
 	  resume_pid = attach_console_temporarily (target_pid);
 	  attach_restore = true;

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -3793,7 +3793,8 @@ skip_create:
   replace_nat_handles (hpConIn, hpConOut);
 
   if (!process_alive (get_ttyp ()->nat_pipe_owner_pid))
-    get_ttyp ()->nat_pipe_owner_pid = myself->exec_dwProcessId;
+    get_ttyp ()->nat_pipe_owner_pid =
+      myself->exec_dwProcessId ? : myself->dwProcessId;
 
   if (hpcon && nat_pipe_owner_self (get_ttyp ()->nat_pipe_owner_pid))
     {
@@ -4503,7 +4504,12 @@ fhandler_pty_slave::setup_for_non_cygwin_app (bool nopcon,
       fhandler_pty_slave *ptys = (fhandler_pty_slave *) fh;
       ptys->get_ttyp ()->switch_to_nat_pipe = true;
       if (!process_alive (ptys->get_ttyp ()->nat_pipe_owner_pid))
-	ptys->get_ttyp ()->nat_pipe_owner_pid = myself->exec_dwProcessId;
+	/* In normal case where the current process is the stub process for
+	   non-cygwin app, set owner to exec_dwProcessId (which is the PID
+	   of the stub process itself). In gdb case, since gdb itself
+	   should be the owner, the owner pid must be set to dwProcessId. */
+	ptys->get_ttyp ()->nat_pipe_owner_pid =
+	  myself->exec_dwProcessId ? : myself->dwProcessId;
     }
   bool pcon_enabled = false;
   if (!nopcon)
@@ -4631,6 +4637,8 @@ fhandler_pty_common::attach_console_temporarily (DWORD target_pid)
 {
   DWORD resume_pid = 0;
   acquire_attach_mutex (mutex_timeout);
+  if (target_pid == GetCurrentProcessId ())
+    return target_pid;
   pinfo pinfo_resume (myself->ppid);
   if (pinfo_resume)
     resume_pid = pinfo_resume->dwProcessId;
@@ -4649,6 +4657,11 @@ fhandler_pty_common::attach_console_temporarily (DWORD target_pid)
 void
 fhandler_pty_common::resume_from_temporarily_attach (DWORD resume_pid)
 {
+  if (resume_pid == GetCurrentProcessId ())
+    {
+      release_attach_mutex ();
+      return;
+    }
   bool console_exists = (resume_pid != (DWORD) -1);
   if (!console_exists || resume_pid)
     {

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -226,6 +226,7 @@ atexit_func (void)
 void
 fhandler_pty_slave::req_fixup_pcon_state (void)
 {
+  ULONGLONG deadline = GetTickCount64 () + 3000;
   while (true)
     {
       WaitForSingleObject (input_mutex, mutex_timeout);
@@ -233,6 +234,10 @@ fhandler_pty_slave::req_fixup_pcon_state (void)
 	break;
       /* Another request is on going. */
       ReleaseMutex (input_mutex);
+      if (GetTickCount64 () > deadline)
+	/* A previous requester is stuck; give up this sync rather than
+	   spin forever. */
+	return;
       yield ();
     }
 
@@ -245,9 +250,25 @@ fhandler_pty_slave::req_fixup_pcon_state (void)
   get_ttyp ()->pcon_start_pid = myself->pid;
   WriteFile (get_output_handle (), "\033[6n", 4, &n, NULL);
   ReleaseMutex (input_mutex);
-  while (get_ttyp ()->pcon_start_pid)
+  deadline = GetTickCount64 () + 3000;
+  while (get_ttyp ()->pcon_start_pid && GetTickCount64 () <= deadline)
     /* wait for completion of fixing-up in master::write(). */
     yield ();
+  /* If the master never answered (e.g. the terminal is going away),
+     clear our own request so a stale pcon_start_pid cannot wedge the
+     next requester. */
+  if (get_ttyp ()->pcon_start_pid == (pid_t) myself->pid)
+    {
+      WaitForSingleObject (input_mutex, mutex_timeout);
+      if (get_ttyp ()->pcon_start_pid == (pid_t) myself->pid)
+	{
+	  get_ttyp ()->req_fixup_pcon_cur_pos = false;
+	  get_ttyp ()->req_xfer_input = false;
+	  get_ttyp ()->pcon_start = false;
+	  get_ttyp ()->pcon_start_pid = 0;
+	}
+      ReleaseMutex (input_mutex);
+    }
 }
 
 void
@@ -4016,6 +4037,13 @@ fhandler_pty_slave::close_pseudoconsole (tty *ttyp, DWORD force_switch_to)
 	  ttyp->pcon_activated = false;
 	  ttyp->switch_to_nat_pipe = false;
 	  ttyp->nat_pipe_owner_pid = 0;
+	  /* Safety net: if a req_fixup_pcon_state() requester died without
+	     clearing its slot, do not leave pcon_start_pid set forever. */
+	  if (ttyp->pcon_start_pid == myself->pid)
+	    {
+	      ttyp->pcon_start = false;
+	      ttyp->pcon_start_pid = 0;
+	    }
 	}
       if (ttyp->pcon_handle_ready_event)
 	{

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -418,6 +418,14 @@ fhandler_pty_master::discard_input ()
   if (!get_ttyp ()->pcon_activated)
     while (::bytes_available (bytes_in_pipe, from_master_nat) && bytes_in_pipe)
       ReadFile (from_master_nat, buf, sizeof(buf), &n, NULL);
+  else
+    {
+      DWORD target_pid = get_ttyp ()->nat_pipe_owner_pid;
+      DWORD resume_pid =
+	fhandler_pty_common::attach_console_temporarily (target_pid);
+      FlushConsoleInputBuffer (h_pcon_in_dupped);
+      fhandler_pty_common::resume_from_temporarily_attach (resume_pid);
+    }
   get_ttyp ()->discard_input = true;
   ReleaseMutex (input_mutex);
 }
@@ -2420,7 +2428,8 @@ fhandler_pty_master::write (const void *ptr, size_t len)
       for (size_t i = 0, j = 0; i < len; i++)
 	{
 	  process_sig_state r = process_sigs (buf[i], get_ttyp (), this);
-	  if (r != done_with_debugger)
+	  if (r != done_with_debugger &&
+	      (r != signalled || (ti.c_lflag & NOFLSH) || buf[i] == '\003'))
 	    {
 	      char c = buf[i];
 	      /* Workaround for pseudo console in Windows 11 */

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -525,6 +525,14 @@ fhandler_pty_master::accept_input ()
 	  p = mbbuf;
 	  bytes_left = nlen;
 	}
+
+      char *p0 = p;
+      if (get_ttyp ()->pcon_activated)
+	while ((p0 = (char *) memchr (p0, '\n', bytes_left - (p0 - p))))
+	  *p0 = '\r';
+      else
+	while ((p0 = (char *) memchr (p0, '\r', bytes_left - (p0 - p))))
+	  *p0 = '\n';
     }
 
   if (!bytes_left)

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -223,6 +223,52 @@ atexit_func (void)
     }
 }
 
+void
+fhandler_pty_slave::req_fixup_pcon_state (void)
+{
+  while (true)
+    {
+      WaitForSingleObject (input_mutex, mutex_timeout);
+      if (!get_ttyp ()->pcon_start_pid)
+	break;
+      /* Another request is on going. */
+      ReleaseMutex (input_mutex);
+      yield ();
+    }
+
+  DWORD n;
+  /* indicates that this "ESC[6n" is just for fixing-up cursor position */
+  get_ttyp ()->req_fixup_pcon_cur_pos = true;
+  get_ttyp ()->req_xfer_input = true; /* indicates that this "ESC[6n"
+					 is just for transfer input */
+  get_ttyp ()->pcon_start = true;
+  get_ttyp ()->pcon_start_pid = myself->pid;
+  WriteFile (get_output_handle (), "\033[6n", 4, &n, NULL);
+  ReleaseMutex (input_mutex);
+  while (get_ttyp ()->pcon_start_pid)
+    /* wait for completion of fixing-up in master::write(). */
+    yield ();
+}
+
+void
+fhandler_pty_master::fixup_pcon_cursor_position (int x, int y)
+{
+  HANDLE pcon_owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE,
+				   get_ttyp ()->nat_pipe_owner_pid);
+  HANDLE h_pcon_out = NULL;
+  DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_out,
+		   GetCurrentProcess (), &h_pcon_out,
+		   0, TRUE, DUPLICATE_SAME_ACCESS);
+  CloseHandle (pcon_owner);
+  DWORD target_pid = get_ttyp ()->nat_pipe_owner_pid;
+  DWORD resume_pid =
+    fhandler_pty_common::attach_console_temporarily (target_pid);
+  COORD cur_pos = {(SHORT) (x - 1), (SHORT) (y - 1)};
+  SetConsoleCursorPosition (h_pcon_out, cur_pos);
+  fhandler_pty_common::resume_from_temporarily_attach (resume_pid);
+  CloseHandle (h_pcon_out);
+}
+
 #define DEF_HOOK(name) static __typeof__ (name) *name##_Orig
 /* CreateProcess() is hooked for GDB etc. */
 DEF_HOOK (CreateProcessA);
@@ -1001,6 +1047,19 @@ err_no_msg:
 bool
 fhandler_pty_slave::open_setup (int flags)
 {
+  if (get_ttyp ()->pcon_activated)
+    {
+      HANDLE pcon_owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE,
+				       get_ttyp ()->nat_pipe_owner_pid);
+      DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_in,
+		       GetCurrentProcess (), &get_handle_nat (),
+		       0, TRUE, DUPLICATE_SAME_ACCESS);
+      DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_out,
+		       GetCurrentProcess (), &get_output_handle_nat (),
+		       0, TRUE, DUPLICATE_SAME_ACCESS);
+      CloseHandle (pcon_owner);
+    }
+
   set_flags ((flags & ~O_TEXT) | O_BINARY);
   myself->set_ctty (this, flags);
   report_tty_counts (this, "opened", "");
@@ -1010,6 +1069,9 @@ fhandler_pty_slave::open_setup (int flags)
 void
 fhandler_pty_slave::cleanup ()
 {
+  if (get_ttyp ()->pcon_activated && get_ttyp ()->getpgid () == myself->pgid)
+    req_fixup_pcon_state ();
+
   /* This used to always call fhandler_pty_common::close when we were execing
      but that caused multiple closes of the handles associated with this pty.
      Since close_all_files is not called until after the cygwin process has
@@ -2311,10 +2373,21 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 	    state = 2;
 	  if (state == 2)
 	    {
-	      /* req_xfer_input is true if "ESC[6n" was sent just for
+	      /* req_fixup_pcon_cur_pos is true if "ESC[6n" was sent
+		 for requesting cursor-position-fixup that is needed
+		 when a non-cygwin app executes a cygwin app and the
+		 cygwin app exits.
+		 req_xfer_input is true if "ESC[6n" was sent just for
 		 triggering transfer_input() in master. In this case,
 		 the response sequence should not be written. */
-	      if (!get_ttyp ()->req_xfer_input)
+	      if (get_ttyp ()->req_fixup_pcon_cur_pos)
+		{
+		  int x, y;
+		  sscanf (wpbuf, "\033[%d;%dR", &y, &x);
+		  fixup_pcon_cursor_position (x, y);
+		  get_ttyp ()->req_fixup_pcon_cur_pos = false;
+		}
+	      else if (!get_ttyp ()->req_xfer_input)
 		WriteFile (to_slave_nat, wpbuf, ixput, &n, NULL);
 	      ixput = 0;
 	      state = 0;
@@ -3934,8 +4007,6 @@ fhandler_pty_slave::close_pseudoconsole (tty *ttyp, DWORD force_switch_to)
 	  ttyp->pcon_activated = false;
 	  ttyp->switch_to_nat_pipe = false;
 	  ttyp->nat_pipe_owner_pid = 0;
-	  ttyp->pcon_start = false;
-	  ttyp->pcon_start_pid = 0;
 	}
       if (ttyp->pcon_handle_ready_event)
 	{

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -2269,7 +2269,6 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 	      ixput = 0;
 	      state = 0;
 	      wp_tid = 0;
-	      get_ttyp ()->req_xfer_input = false;
 	      get_ttyp ()->pcon_start = false;
 	      break;
 	    }
@@ -2283,6 +2282,20 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 	      && pp && pp->pgid == get_ttyp ()->getpgid ()
 	      && get_ttyp ()->pty_input_state_eq (tty::to_cyg))
 	    {
+	      if (!get_ttyp ()->req_xfer_input)
+		{
+		  HANDLE pcon_handle_ready_event =
+		    get_ttyp ()->pcon_handle_ready_event;
+		  get_handle_from_process (get_ttyp ()->nat_pipe_owner_pid,
+					   pcon_handle_ready_event);
+		  if (pcon_handle_ready_event)
+		    {
+		      cygwait (pcon_handle_ready_event, INFINITE);
+		      ResetEvent (pcon_handle_ready_event);
+		      CloseHandle (pcon_handle_ready_event);
+		    }
+		}
+
 	      /* This accept_input() call is needed in order to transfer input
 		 which is not accepted yet to non-cygwin pipe. */
 	      WaitForSingleObject (input_mutex, mutex_timeout);
@@ -2296,6 +2309,7 @@ fhandler_pty_master::write (const void *ptr, size_t len)
 	      release_attach_mutex ();
 	      ReleaseMutex (input_mutex);
 	    }
+	  get_ttyp ()->req_xfer_input = false;
 	  get_ttyp ()->pcon_start_pid = 0;
 	}
       if (len == 0)
@@ -3589,6 +3603,8 @@ fhandler_pty_slave::setup_pseudoconsole ()
       si.StartupInfo.hStdOutput = NULL;
       si.StartupInfo.hStdError = NULL;
 
+      get_ttyp ()->pcon_handle_ready_event =
+	CreateEvent (&sec_none_nih, TRUE, FALSE, NULL);
       get_ttyp ()->pcon_activated = true;
       get_ttyp ()->pcon_start = true;
       get_ttyp ()->pcon_start_pid = myself->pid;
@@ -3675,6 +3691,7 @@ skip_create:
       /* Discard the pseudo console handler container here.
 	 Reconstruct it temporary when it is needed. */
       HeapFree (GetProcessHeap (), 0, hp);
+      SetEvent (get_ttyp ()->pcon_handle_ready_event);
     }
 
   acquire_attach_mutex (mutex_timeout);
@@ -3881,6 +3898,11 @@ fhandler_pty_slave::close_pseudoconsole (tty *ttyp, DWORD force_switch_to)
 	  ttyp->nat_pipe_owner_pid = 0;
 	  ttyp->pcon_start = false;
 	  ttyp->pcon_start_pid = 0;
+	}
+      if (ttyp->pcon_handle_ready_event)
+	{
+	  CloseHandle (ttyp->pcon_handle_ready_event);
+	  ttyp->pcon_handle_ready_event = NULL;
 	}
     }
   else
@@ -4134,6 +4156,26 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
 
   UINT cp_from = 0, cp_to = 0;
 
+  HANDLE h_pcon_in = NULL;
+  DWORD con_mode = 0;
+  if (ttyp->pcon_activated && dir == tty::to_nat)
+    {
+      /* Escape sequences such as the cursor position report ("CSI m;n R")
+	 are undesirably converted into an Fn3 key by pseudo console.
+	 To privent this unintended conversion, temporarily enable
+	 ENABLE_VIRTUAL_TERMINAL_INPUT flag. */
+      h_pcon_in =
+	get_handle_from_process (ttyp->nat_pipe_owner_pid, ttyp->h_pcon_in);
+      if (h_pcon_in)
+	{
+	  DWORD target_pid = ttyp->nat_pipe_owner_pid;
+	  DWORD resume_pid = attach_console_temporarily (target_pid);
+	  GetConsoleMode (h_pcon_in, &con_mode);
+	  SetConsoleMode (h_pcon_in, con_mode | ENABLE_VIRTUAL_TERMINAL_INPUT);
+	  resume_from_temporarily_attach (resume_pid);
+	}
+    }
+
   if (dir == tty::to_nat)
     {
       cp_from = ttyp->term_code_page;
@@ -4247,6 +4289,15 @@ fhandler_pty_slave::transfer_input (tty::xfer_dir dir, HANDLE from, tty *ttyp,
 	}
     }
   CloseHandle (to);
+
+  if (h_pcon_in)
+    {
+      DWORD target_pid = ttyp->nat_pipe_owner_pid;
+      DWORD resume_pid = attach_console_temporarily (target_pid);
+      SetConsoleMode (h_pcon_in, con_mode);
+      resume_from_temporarily_attach (resume_pid);
+      CloseHandle (h_pcon_in);
+    }
 
   ttyp->pty_input_state = dir;
   /* Fix input_available_event which indicates availability in cyg pipe. */

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -1072,13 +1072,33 @@ fhandler_pty_slave::open_setup (int flags)
     {
       HANDLE pcon_owner = OpenProcess (PROCESS_DUP_HANDLE, FALSE,
 				       get_ttyp ()->nat_pipe_owner_pid);
-      DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_in,
-		       GetCurrentProcess (), &get_handle_nat (),
-		       0, TRUE, DUPLICATE_SAME_ACCESS);
-      DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_out,
-		       GetCurrentProcess (), &get_output_handle_nat (),
-		       0, TRUE, DUPLICATE_SAME_ACCESS);
-      CloseHandle (pcon_owner);
+      if (pcon_owner)
+	{
+	  HANDLE new_in = NULL, new_out = NULL;
+	  bool ok_in = DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_in,
+				       GetCurrentProcess (), &new_in,
+				       0, TRUE, DUPLICATE_SAME_ACCESS);
+	  bool ok_out = DuplicateHandle (pcon_owner, get_ttyp ()->h_pcon_out,
+				        GetCurrentProcess (), &new_out,
+				        0, TRUE, DUPLICATE_SAME_ACCESS);
+	  if (ok_in && ok_out)
+	    {
+	      /* Close the cyg master-side handles open() installed before
+		 replacing them, so they do not leak. */
+	      CloseHandle (get_handle_nat ());
+	      CloseHandle (get_output_handle_nat ());
+	      set_handle_nat (new_in);
+	      set_output_handle_nat (new_out);
+	    }
+	  else
+	    {
+	      if (new_in)
+		CloseHandle (new_in);
+	      if (new_out)
+		CloseHandle (new_out);
+	    }
+	  CloseHandle (pcon_owner);
+	}
     }
 
   set_flags ((flags & ~O_TEXT) | O_BINARY);

--- a/winsup/cygwin/fhandler/pty.cc
+++ b/winsup/cygwin/fhandler/pty.cc
@@ -2764,7 +2764,6 @@ fhandler_pty_master::apply_line_edit_to_transferred_input ()
       n -= ret;
       p += ret;
     }
-  SetEvent (input_available_event);
 }
 
 static DWORD

--- a/winsup/cygwin/fhandler/termios.cc
+++ b/winsup/cygwin/fhandler/termios.cc
@@ -353,7 +353,10 @@ fhandler_termios::process_sigs (char c, tty* ttyp, fhandler_termios *fh)
 	      fhandler_pty_common::attach_console_temporarily (p->dwProcessId);
 	  if (fh && p == myself && being_debugged ())
 	    { /* Avoid deadlock in gdb on console. */
-	      fh->tcflush(TCIFLUSH);
+	      if (fh->is_console ())
+		fh->discard_key_events (0 /* to current position */);
+	      else
+		fh->tcflush(TCIFLUSH);
 	      fh->release_input_mutex_if_necessary ();
 	    }
 	  /* CTRL_C_EVENT does not work for the process started with
@@ -444,10 +447,14 @@ fhandler_termios::process_sigs (char c, tty* ttyp, fhandler_termios *fh)
 	goto not_a_sig;
 
       termios_printf ("got interrupt %d, sending signal %d", c, sig);
-      if (!(ti.c_lflag & NOFLSH) && fh)
+      if (fh)
 	{
-	  fh->eat_readahead (-1);
-	  fh->discard_input ();
+	  if (!(ti.c_lflag & NOFLSH))
+	    {
+	      fh->eat_readahead (-1);
+	      fh->discard_input ();
+	    }
+	  fh->discard_key_events (0 /* to current position */);
 	}
       if (fh)
 	fh->release_input_mutex_if_necessary ();
@@ -460,6 +467,8 @@ fhandler_termios::process_sigs (char c, tty* ttyp, fhandler_termios *fh)
 not_a_sig:
   if ((ti.c_lflag & ISIG) && need_discard_input)
     {
+      if (need_send_sig)
+	return not_signalled;
       if (!(ti.c_lflag & NOFLSH) && fh)
 	{
 	  fh->eat_readahead (-1);
@@ -525,10 +534,11 @@ fhandler_termios::line_edit (const char *rptr, size_t nread, termios& ti,
       switch (process_sigs (c, get_ttyp (), this))
 	{
 	case signalled:
-	case not_signalled_but_done:
 	case done_with_debugger:
 	  sawsig = true;
 	  get_ttyp ()->output_stopped = false;
+	  fallthrough;
+	case not_signalled_but_done:
 	  continue;
 	case not_signalled_with_nat_reader:
 	  disable_eof_key = true;
@@ -666,13 +676,9 @@ fhandler_termios::sigflush ()
      be NULL while this is alive.  However, we can conceivably close a
      ctty while exiting and that will zero this. */
   if ((!have_execed || have_execed_cygwin) && tc ()
-      && (tc ()->getpgid () == myself->pgid))
-    {
-      if (!(tc ()->ti.c_lflag & NOFLSH))
-	tcflush (TCIFLUSH);
-      else
-	discard_key_events (1);
-    }
+      && (tc ()->getpgid () == myself->pgid)
+      && !(tc ()->ti.c_lflag & NOFLSH))
+    tcflush (TCIFLUSH);
 }
 
 pid_t

--- a/winsup/cygwin/fhandler/termios.cc
+++ b/winsup/cygwin/fhandler/termios.cc
@@ -666,9 +666,13 @@ fhandler_termios::sigflush ()
      be NULL while this is alive.  However, we can conceivably close a
      ctty while exiting and that will zero this. */
   if ((!have_execed || have_execed_cygwin) && tc ()
-      && (tc ()->getpgid () == myself->pgid)
-      && !(tc ()->ti.c_lflag & NOFLSH))
-    tcflush (TCIFLUSH);
+      && (tc ()->getpgid () == myself->pgid))
+    {
+      if (!(tc ()->ti.c_lflag & NOFLSH))
+	tcflush (TCIFLUSH);
+      else
+	discard_key_events (1);
+    }
 }
 
 pid_t

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -2324,7 +2324,7 @@ private:
     fh->copy_from (this);
     return fh;
   }
-  input_states process_input_message ();
+  input_states process_input_message (size_t len);
   bg_check_types bg_check (int sig, bool dontsignal = false);
   void setup_io_mutex (void);
   DWORD __acquire_input_mutex (const char *fn, int ln, DWORD ms);

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -2200,6 +2200,7 @@ private:
   HANDLE input_mutex, output_mutex;
   handle_set_t handle_set;
   _minor_t unit;
+  size_t num_input_events_processed;
 
   /* Used when we encounter a truncated multi-byte sequence.  The
      lead bytes are stored here and revisited in the next write call. */

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -2529,6 +2529,7 @@ class fhandler_pty_slave: public fhandler_pty_common
   void setpgid_aux (pid_t pid);
   static void release_ownership_of_nat_pipe (tty *ttyp, fhandler_termios *fh);
   void replace_nat_handles (HANDLE new_input, HANDLE new_output);
+  void req_fixup_pcon_state (void);
 };
 
 #define __ptsname(buf, unit) __small_sprintf ((buf), "/dev/pty%d", (unit))
@@ -2636,6 +2637,7 @@ public:
   void apply_line_edit_to_transferred_input ();
   line_edit_status line_edit_maybe (const char *p, size_t len, termios&,
 				    ssize_t *n);
+  void fixup_pcon_cursor_position (int x, int y);
 };
 
 class fhandler_dev_null: public fhandler_base

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -1982,6 +1982,7 @@ class fhandler_termios: public fhandler_base
   virtual off_t lseek (off_t, int);
   pid_t tcgetsid ();
   virtual int fstat (struct stat *buf);
+  virtual void discard_key_events (size_t n) {}
 
   fhandler_termios (void *) {}
 
@@ -2360,6 +2361,7 @@ private:
   void wpbuf_put (char c);
   void wpbuf_send ();
   int fstat (struct stat *buf);
+  void discard_key_events (size_t n);
 
   class console_unit
   {

--- a/winsup/cygwin/local_includes/fhandler.h
+++ b/winsup/cygwin/local_includes/fhandler.h
@@ -2632,6 +2632,8 @@ public:
   void get_master_fwd_thread_param (master_fwd_thread_param_t *p);
   bool need_send_ctrl_c_event ();
   void apply_line_edit_to_transferred_input ();
+  line_edit_status line_edit_maybe (const char *p, size_t len, termios&,
+				    ssize_t *n);
 };
 
 class fhandler_dev_null: public fhandler_base

--- a/winsup/cygwin/local_includes/tty.h
+++ b/winsup/cygwin/local_includes/tty.h
@@ -175,6 +175,10 @@ public:
   void wait_fwd ();
   bool pty_input_state_eq (xfer_dir x) { return pty_input_state == x; }
   bool nat_fg (pid_t pgid);
+  bool has_active_pcon () const
+    { return pcon_activated && switch_to_nat_pipe; }
+  bool has_pcon_and_owner (DWORD pid) const
+    { return pcon_activated && switch_to_nat_pipe && nat_pipe_owner_pid == pid; }
   friend class fhandler_pty_common;
   friend class fhandler_pty_master;
   friend class fhandler_pty_slave;
@@ -193,6 +197,7 @@ public:
   int connect (int);
   void init ();
   tty_min *get_cttyp ();
+  int find_pcon_pty ();
   int attach (int n);
   static void init_session ();
   friend class lock_ttys;

--- a/winsup/cygwin/local_includes/tty.h
+++ b/winsup/cygwin/local_includes/tty.h
@@ -120,6 +120,7 @@ private:
   pid_t pcon_start_pid;
   bool switch_to_nat_pipe;
   DWORD nat_pipe_owner_pid;
+  HANDLE pcon_handle_ready_event;
   UINT term_code_page;
   ULONGLONG fwd_last_time;
   bool fwd_not_empty;

--- a/winsup/cygwin/local_includes/tty.h
+++ b/winsup/cygwin/local_includes/tty.h
@@ -140,6 +140,7 @@ private:
   xfer_dir pty_input_state;
   bool discard_input;
   bool stop_fwd_thread;
+  bool req_fixup_pcon_cur_pos;
 
 public:
   HANDLE from_master_nat () const { return _from_master_nat; }

--- a/winsup/cygwin/local_includes/tty.h
+++ b/winsup/cygwin/local_includes/tty.h
@@ -176,6 +176,10 @@ public:
   void wait_fwd ();
   bool pty_input_state_eq (xfer_dir x) { return pty_input_state == x; }
   bool nat_fg (pid_t pgid);
+  bool has_active_pcon () const
+    { return pcon_activated && switch_to_nat_pipe; }
+  bool has_pcon_and_owner (DWORD pid) const
+    { return pcon_activated && switch_to_nat_pipe && nat_pipe_owner_pid == pid; }
   friend class fhandler_pty_common;
   friend class fhandler_pty_master;
   friend class fhandler_pty_slave;
@@ -194,6 +198,7 @@ public:
   int connect (int);
   void init ();
   tty_min *get_cttyp ();
+  int find_pcon_pty ();
   int attach (int n);
   static void init_session ();
   friend class lock_ttys;

--- a/winsup/cygwin/select.cc
+++ b/winsup/cygwin/select.cc
@@ -1172,7 +1172,7 @@ peek_console (select_record *me, bool)
 	  if (!r || !events_read)
 	    break;
 	}
-      if (fhandler_console::input_winch == fh->process_input_message ()
+      if (fhandler_console::input_winch == fh->process_input_message (0)
 	  && global_sigs[SIGWINCH].sa_handler != SIG_IGN
 	  && global_sigs[SIGWINCH].sa_handler != SIG_DFL)
 	{

--- a/winsup/cygwin/tty.cc
+++ b/winsup/cygwin/tty.cc
@@ -123,6 +123,43 @@ tty_list::init ()
     }
 }
 
+/* Search for a pty whose pseudo console owns our console.
+   Return tty minor number or -1 if not found.
+   Called from init_std_file_from_handle() for processes started by
+   non-Cygwin parents to detect that inherited console handles are
+   from a pcon-backed pty.
+
+   The cheap precondition (any tty with pcon active in shared memory)
+   short-circuits the common case where no pty has a pseudo console
+   active, avoiding the GetConsoleProcessList() LPC call entirely. */
+int
+tty_list::find_pcon_pty ()
+{
+  DWORD pids[128];
+  DWORD count = 0;
+  bool got_pids = false;
+
+  for (int i = 0; i < NTTYS; i++)
+    {
+      if (!ttys[i].has_active_pcon ())
+	continue;
+
+      /* Fetch the console process list lazily, only on first candidate. */
+      if (!got_pids)
+	{
+	  count = GetConsoleProcessList (pids, 128);
+	  if (!count)
+	    return -1;
+	  got_pids = true;
+	}
+
+      for (DWORD j = 0; j < count; j++)
+	if (ttys[i].has_pcon_and_owner (pids[j]))
+	  return i;
+    }
+  return -1;
+}
+
 /* Search for a free tty and allocate it.
    Return tty number or -1 if error.
  */

--- a/winsup/cygwin/tty.cc
+++ b/winsup/cygwin/tty.cc
@@ -19,6 +19,7 @@ details. */
 #include "cygheap.h"
 #include "pinfo.h"
 #include "shared_info.h"
+#include "tls_pbuf.h"
 
 HANDLE NO_COPY tty_list::mutex = NULL;
 
@@ -135,7 +136,9 @@ tty_list::init ()
 int
 tty_list::find_pcon_pty ()
 {
-  DWORD pids[128];
+  tmp_pathbuf tp;
+  DWORD *pids = (DWORD *) tp.c_get ();
+  const DWORD buf_size = NT_MAX_PATH / sizeof (DWORD);
   DWORD count = 0;
   bool got_pids = false;
 
@@ -144,10 +147,20 @@ tty_list::find_pcon_pty ()
       if (!ttys[i].has_active_pcon ())
 	continue;
 
-      /* Fetch the console process list lazily, only on first candidate. */
+      /* Fetch the console process list lazily, only on first candidate.
+	 The buffer-too-large dance mirrors the one in termios.cc's
+	 get_console_process_id() and works around new condrv's dislike
+	 of oversized first-call buffers, see
+	 https://github.com/microsoft/terminal/issues/18264#issuecomment-2515448548 */
       if (!got_pids)
 	{
-	  count = GetConsoleProcessList (pids, 128);
+	  DWORD buf_size1 = 1;
+	  while ((count = GetConsoleProcessList (pids, buf_size1)) > buf_size1)
+	    {
+	      if (count > buf_size)
+		return -1;
+	      buf_size1 = count;
+	    }
 	  if (!count)
 	    return -1;
 	  got_pids = true;


### PR DESCRIPTION
When `bash` (Cygwin, under MinTTY) spawns `git.exe` (native Win32) with pseudo console support enabled, and `git.exe` then spawns a Cygwin grandchild (`vim`, `less`, `sh`), the grandchild inherits the pseudo console's console handles. The msys2-runtime classifies those handles as `FH_CONSOLE`, giving the process `cons0` instead of connecting to the pty (`pty0`).

On `cons0`, alternate screen sequences (`ESC[?1049h` / `ESC[?1049l`) are handled by `fhandler_console`'s `save_restore()` against the pseudo console's buffer rather than by MinTTY against its scrollback, causing the visible scrollback to be clobbered when the editor/pager exits.

This was reported in https://github.com/git-for-windows/git/issues/5303 and bisected to Git for Windows v2.41.0 (msys2-runtime 3.3.6 to 3.4.6, when the pseudo console architecture was introduced).

The fix scans the shared tty table during `stdio_init()` for a tty whose pseudo console owner PID is in our console's process list (via `GetConsoleProcessList`). If found, `myself->ctty` is set to that pty device before the standard `GetStdHandle` / `init_std_file_from_handle` path runs, so the existing `CTTY_IS_VALID` branch creates an `fhandler_pty_slave` that connects to the pty.

Verified locally: with this fix, `GIT_EDITOR=vim git commit --amend` no longer clobbers the scrollback in MinTTY.
