### PR TITLE
Upgrade GitHub Actions in CI workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
           make DESTDIR="$(pwd)"/_dest install
 
       - name: Upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: install
           path: _dest/
@@ -81,7 +81,7 @@ jobs:
           msys2 -c 'pacman --noconfirm -Suu'
 
       - name: Download msys2-runtime artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: install
           path: ${{ steps.msys2.outputs.msys2-location }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
         # Cannot just grab from https://github.com/git-for-windows/git-sdk-64/releases/tag/ci-artifacts
         # because we also need the git-artifacts
         id: ci-artifacts-run-id
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const [ owner, repo ] = process.env.G4W_SDK_REPO.split('/')
@@ -80,7 +80,7 @@ jobs:
             exit $?
           done
           ls -la
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: install
           path: install
@@ -94,7 +94,7 @@ jobs:
           tar -C ../install -cf - . | tar xf - &&
           tar cvf - * .[0-9A-Za-z]* | gzip -1 >../git-sdk-x86_64-minimal.tar.gz
       - name: upload minimal-sdk artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: minimal-sdk
           path: git-sdk-x86_64-minimal.tar.gz
@@ -107,7 +107,7 @@ jobs:
           echo "result=$(tar Oxf git-artifacts.tar.gz git/bin-wrappers/git |
             sed -n 's|^GIT_EXEC_PATH='\''\(.*\)/git'\''$|\1|p')" >>$GITHUB_OUTPUT
       - name: upload git artifacts for testing
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: git-artifacts
           path: git-artifacts.tar.gz

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -168,7 +168,7 @@ jobs:
 
     # upload test logs to facilitate investigation of problems
     - name: Upload test logs
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: testlogs
         path: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -183,7 +183,7 @@ jobs:
           screenshot $bounds "ui-tests/screenshot.png"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ui-tests-${{ matrix.os }}
           path: ui-tests

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.msys2-runtime-artifact-name }}
           path: ${{ runner.temp }}/artifacts


### PR DESCRIPTION
This PR brings the GitHub Actions referenced in this repository's workflows up to their current latest stable major versions.

It supersedes the still-open Dependabot PRs #125 (`upload-artifact` 6 -> 7), #126 (`download-artifact` 7 -> 8), and #129 (`github-script` 8 -> 9), bundling them into the existing branch-ticket structure rather than landing each as an isolated direct-on-`main` commit. The changes are:

- `actions/checkout` -> v6 (already at v6 for new workflows; bumped from v3 in the inherited `cygwin.yml`)
- `actions/upload-artifact` -> v7 (bumped from v6 in cygwin.yml, build.yaml, ui-tests.yml; from v4 in the older fixup chain)
- `actions/download-artifact` -> v8 (bumped from v7 in build.yaml and ui-tests.yml)
- `actions/github-script` -> v9 (bumped from v8 in build.yaml)
- `actions/cache` -> v5 (already current)
- `actions/setup-node` -> v6 (already current)

The aggregate diff against `main` is exactly nine lines changed (nine deletions, nine insertions) across `cygwin.yml`, `build.yaml`, and `ui-tests.yml`. No behavioral changes: every step continues to use default arguments and the new optional features (direct unzipped uploads in `upload-artifact@v7`, `Content-Type`-aware unzipping in `download-artifact@v8`, the new `getOctokit` factory in `github-script@v9`, etc.) are not exercised here.

The branch follows the existing merging-rebase layering. Each incremental bump is rooted in the layer where the action reference ultimately lives:

- A new sub-branch `update-github-actions-in-cygwin-ci` carrying one `fixup!` of `4bd00d615b Cygwin: CI: update Actions versions` (the only Cygwin-layer bump still needed: `upload-artifact` v6 to v7 in `cygwin.yml`).
- A new sub-branch `msys2-ci-fixups` carrying one `fixup!` of `cd1436184d CI: add a GHA for doing a basic build test` (the
  build.yaml `upload-artifact` v6->v7 and `download-artifact` v7->v8 bumps).
- Three GFW-only `fixup!` commits directly on the branch tip, targeting the GFW commits that introduced the additional action references that aren't in upstream MSYS2:
  - `fixup! ci: run Git's entire test suite` (build.yaml: `github-script` v8->v9, `download-artifact` v7->v8,
    `upload-artifact` v6->v7 x2)
  - `fixup! ci: add an AutoHotKey-based integration test` (ui-tests.yml `download-artifact` v7->v8)
  - `fixup! ci(ui-tests): upload the test logs` (ui-tests.yml `upload-artifact` v6->v7)

While in the area, this PR also adds `amend!` commits that replace the dependabot-style boilerplate on five existing GFW-only commits with prose that actually explains what each change does, why, and how it affects the workflow.