### PR TITLE
Merge msys2-3.6.9: fix GCC 16 build error, add libzstd-devel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           msystem: MSYS
           update: true
-          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel xmlto docbook-xsl
+          install: msys2-devel base-devel autotools cocom diffutils gcc gettext-devel libiconv-devel make mingw-w64-cross-crt mingw-w64-cross-gcc mingw-w64-cross-zlib perl zlib-devel xmlto docbook-xsl libzstd-devel
 
       - name: Build
         shell: msys2 {0}

--- a/ui-tests/ctrl-c.ahk
+++ b/ui-tests/ctrl-c.ahk
@@ -134,7 +134,7 @@ if (openSSHPath != '' and FileExist(openSSHPath . '\sshd.exe')) {
     Sleep 50
     Info('Waiting for clone to start')
     WinActivate('ahk_id ' . hwnd)
-    WaitForRegExInWindowsTerminal('remote: ', 'Timed out waiting for clone to start', 'Clone started', 5000, 'ahk_id ' . hwnd)
+    WaitForRegExInWindowsTerminal('remote: ', 'Timed out waiting for clone to start', 'Clone started', 15000, 'ahk_id ' . hwnd)
     Info('Trying to interrupt clone')
     Send('^C') ; interrupt clone
     Sleep 150

--- a/ui-tests/ctrl-c.ahk
+++ b/ui-tests/ctrl-c.ahk
@@ -44,7 +44,7 @@ WaitForRegExInWindowsTerminal('>[ `n`r]*$', 'Timed out waiting for interrupt', '
 ; ping test (`cat.exe` should be interrupted, too)
 Send('git -c alias.c="{!}cat | /c/windows/system32/ping -t localhost" c{Enter}')
 Sleep 500
-WaitForRegExInWindowsTerminal('Pinging ', 'Timed out waiting for pinging to start', 'Pinging started')
+WaitForRegExInWindowsTerminal('Pinging ', 'Timed out waiting for pinging to start', 'Pinging started', 10000)
 Send('^C') ; interrupt ping and cat
 Sleep 150
 ; Wait for the `^C` tell-tale to appear

--- a/winsup/utils/mingw/cygcheck.cc
+++ b/winsup/utils/mingw/cygcheck.cc
@@ -1706,7 +1706,6 @@ dump_sysinfo ()
   else
     {
       char sep = strchr (s, ';') ? ';' : ':';
-      int count_path_items = 0;
       while (1)
 	{
 	  for (e = s; *e && *e != sep; e++);
@@ -1714,7 +1713,6 @@ dump_sysinfo ()
 	    printf ("\t%.*s\n", (int) (e - s), s);
 	  else
 	    puts ("\t.");
-	  count_path_items++;
 	  if (!*e)
 	    break;
 	  s = e + 1;


### PR DESCRIPTION
This merges the msys2-3.6.9 branch from the MSYS2 fork, picking up two new patches on top of the existing cygwin-3.6.9 base:

The first patch removes an unused variable in cygcheck that causes a build error with GCC 16 (which now treats `-Wunused-but-set-variable` as an error by default).

The second patch adds the missing `libzstd-devel` build dependency to the CI workflow, needed because binutils now pulls in zstd and the Cygwin build system only considers linking against it when the development headers are present at configure time.

While at it, fix up the UI tests to squash two flakes that hit this here PR, by extending some timeouts.


Closes git-for-windows/git#6252
